### PR TITLE
Renamed weekday-of-month to day-of-week-in-month

### DIFF
--- a/S32-setting-library/Temporal.pod
+++ b/S32-setting-library/Temporal.pod
@@ -200,8 +200,8 @@ December may be placed in the first week of the next year.
 There's a C<day-of-week> method, which returns the day of the week as a
 number 1..7, with 1 being Monday and 7 being Sunday.
 
-The C<weekday-of-month> method returns a number 1..5 indicating the
-number of times a particular weekday has occurred so far during that
+The C<day-of-week-in-month> method returns a number 1..5 indicating the
+number of times a particular day-of-week has occurred so far during that
 month, the day itself included. For example, June 9, 2003 is the second
 Monday of the month, and so this method returns 2 for that day.
 
@@ -264,7 +264,7 @@ like their C<DateTime> equivalents:
     week-year
     week-number
     day-of-week
-    weekday-of-month
+    day-of-week-in-month
     days-in-month
     day-of-year
     is-leap-year


### PR DESCRIPTION
Weekday usually means any day of the week other than a day that occurs in
the weekend unless the API is constrained by struct tm. Which uses wday.
## 

chansen
