### PR TITLE
Match vars begin at $0 in Perl 6

### DIFF
--- a/S28-special-names.pod
+++ b/S28-special-names.pod
@@ -155,7 +155,7 @@ If a column has a "-" in it, it means that item is unavailable in that version o
  $_[1],$_[2]..       $^a,$^b..
  $a,$b               -              Just params to anonymous block
  -                   $/             Object with results of last regex match
- $1,$2,$3...         $1,$2,$3...
+ $1,$2,$3...         $0,$1,$2...    Match capture variables start at 0
  $& $MATCH           $<>
  $` $PREMATCH        substr based on $/.from
  $' $POSTMATCH       substr based on $/.to


### PR DESCRIPTION
S28 disagreed with S05 on where match variables start in Perl 6
