### PR TITLE
revised intros and added content.pod

### DIFF
--- a/contents.pod
+++ b/contents.pod
@@ -1,0 +1,1366 @@
+Synopsis 1: Overview
+S01 provides an overview of the Perl 6 history and project
+Chapter contents:
+	History
+	What Defines Perl 6? Tests, Synopses, STD.
+	Document Status
+	Project Plan
+	Random Thoughts
+
+Synopsis 2: Bits and Pieces
+S02 covers small-scale lexical items and typological issues.
+Chapter contents:
+	One-pass parsing
+	Lexical Conventions
+		Unicode Semantics
+		Bracketing Characters
+		Multiline Comments
+		Single-line Comments
+		Embedded Comments
+		User-selected Brackets
+		Unspaces
+		Comments in Unspaces and vice versa
+		Optional Whitespace and Exclusions
+			Implicit Topical Method Calls
+	Built-In Data Types
+		The P6opaque Datatype
+		Name Equivalence of Types
+		Properties on Objects
+			Traits
+		Types as Constraints
+		Container Types
+		Nil
+		Type Objects
+		Coercive type declarations
+		Containers of Native Types
+		Methods on Arrays
+		Built-in Type Conventions
+			The C<.WHICH> Method for Value Types
+			The C<ObjAt> Type
+		Variables Containing Undefined Values
+		The C<HOW> Method
+		Roles
+		The C<Num> and C<Rat> Types
+		Infinity and C<NaN>
+		Strings, the C<Str> Type
+			The C<StrPos> Type
+			The C<StrLen> Type
+			Units of Position Arguments
+			Numeric Coercion of C<StrPos> or C<StrLen>
+		The C<Buf> Type
+			Native C<buf> Types
+		The C<Whatever> Object
+			Autopriming of Unary and Binary Operators with Whatever
+			The C<WhateverCode> Types
+			Operators with idiosyncratic Whatever
+			Non-closure-returning Operators with C<*>
+			The C<HyperWhatever> Type
+		Native types
+		The C<Mu> type
+		Undefined types
+		Immutable types
+		Mutable types
+		Of types
+		Container types
+		Hierarchical types
+		Parameter types
+		Generic types
+	The Cool class (and package)
+	Names and Variables
+		Apostrophe separator
+		Sigils
+			Sigils indicate interface
+			No intervening whitespace
+		Twigils
+		Scope declarators
+		Invariant sigils
+		List stringification
+		The C<.perl> method
+		The C<.gist> method
+		The C<.fmt> method
+		Subscripts
+			Subscripts have list context
+		List assignment and binding
+		Parcels
+		Parcels, parameters, and Captures
+		CaptureCursors
+		Signature objects
+		Ampersand and invocation
+		Specifying a dispatch candidate
+		Multidimensional slices and parcels
+		Subscript adverbs
+		Combining subscript adverbs
+		Numeric and boolean context of hashes
+		List sorting
+		Special variables
+		Array end index
+	Names
+		Package-qualified names
+		Pseudo-packages
+		Interpolating into names
+		Strict lookup
+		Direct lookup
+		Symbol tables
+		Dynamic lookup
+		C<DYNAMIC>
+		Package lookup
+		Globals
+		The C<PROCESS> package
+		Dynamic variable creation
+		The magic input handle
+		Magical access to documentation
+		Magical lexically scoped values
+		The C<COMPILING> pseudopackage
+		Switching parsers
+		Slangs
+		Extended identifiers
+	Literals
+		Underscores
+		Radix markers
+		General radices
+		Exponentials
+		Rational literals
+		Complex literals
+		C<Blob> literals
+		Radix interpolation
+		Angle quotes (quote words)
+			Explicit Parcel construction
+			Disallowed forms
+			Relationship between <> and «»
+		Adverbial Pair forms
+		C<Q> forms
+		Adverbs on quotes
+		The C<:val> modifier
+		Whitespace before adverbs
+		Delimiters of quoting forms
+		Quotes from Macros
+		Interpolating into a single-quoted string
+		Interpolation rules
+			Arrays
+			Hashes
+			Sub calls
+			Method calls
+			Multiple dereferencers
+			Closures
+			Twigils
+			Other expressions
+			Class methods
+			Old disambiguation
+			Topical methods
+			Function calls
+			Backslash sequences
+			Other functions
+			Unicode codepoints
+			Backslashing
+		Bare identifiers
+		Dereferences
+		Hash subscripts and bare keys
+		Double-underscore forms
+		Heredocs
+			Optional whitespace
+			One-pass heredoc parsing
+		Allomorphic value semantics
+			Allomorphic Rats
+	Context
+	Lists
+		Lazy flattening
+		C<list>, C<flat>, C<item>, and C<.tree>
+		Forcing capture context
+		The C<eager> operator
+		The C<hyper> operator
+		The C<race> operator
+		The C<< => >> operator
+		The C<< .. >> operator
+		Hash assignment
+		The anonymous C<enum> function
+		Hash binding
+	Files
+	Grammatical Categories
+	Deprecations
+
+Synopsis 3: Perl 6 Operators
+S03 deals with Operators. Perl 6 has a rich set of operators, which can be extended by an author.
+
+For a summary of the changes from Perl 5, see L</Changes to Perl 5 operators>.
+Chapter contents:
+	Operator precedence
+		Term precedence
+		Method postfix precedence
+		Autoincrement precedence
+		Exponentiation precedence
+		Symbolic unary precedence
+		Multiplicative precedence
+		Additive precedence
+		Replication
+		Concatenation
+		Junctive and (all) precedence
+		Junctive or (any) precedence
+		Named unary precedence
+		Nonchaining binary precedence
+		Chaining binary precedence
+		Tight and precedence
+		Tight or precedence
+		Conditional operator precedence
+	Adverbs
+		Item assignment precedence
+		Loose unary precedence
+		Comma operator precedence
+		List infix precedence
+		List prefix precedence
+		Loose and precedence
+		Loose or precedence
+		Terminator precedence
+	Changes to Perl 5 operators
+	Junctive operators
+	Comparison semantics
+	Range and RangeIter semantics
+		Unary ranges
+		Auto-priming of ranges
+	Chained comparisons
+	Smart matching
+	Invocant marker
+	Feed operators
+	Meta operators
+		Assignment operators
+		Negated relational operators
+		Reversed operators
+		Hyper operators
+			Unary hyper operators
+				Non-structural unary hyper operators
+				Structural unary hyper operators
+			Binary hyper operators
+		Reduction operators
+		Cross operators
+		Zip operators
+		Sequential operators
+		Nesting of metaoperators
+		Turning an infix operator into a noun
+		Turning a binary function into an infix
+	Declarators
+	Argument List Interpolating
+	Traversing arrays in parallel
+	Minimal whitespace DWIMmery
+	Sequence points
+
+Synopsis 4: Blocks and Statements
+S04 covers the block and statement syntax of Perl.
+Chapter contents:
+	The Relationship of Lexical and Dynamic Scopes
+	The Relationship of Blocks and Declarations
+	The Relationship of Blocks and Statements
+	Statement-ending blocks
+	Conditional statements
+	Loop statements
+		The C<while> and C<until> statements
+		The C<repeat> statement
+		The general loop statement
+		The C<for> statement
+		The do-once loop
+		Loops at the statementlist level vs the statement level
+		Statement-level bare blocks
+		The C<gather> statement prefix
+		Other C<do>-like forms
+	Switch statements
+	Exception handlers
+	Control Exceptions
+	The goto statement
+	Exceptions
+	Phasers
+	Statement parsing
+	Definition of Success
+	When is a closure not a closure
+
+Synopsis 5: Regexes and Rules
+S05 is about the new regex syntax.
+
+Code expressions with Perl 6 regex syntax are now called I<regex> rather than "regular
+expressions" because they have a richer syntax than regular expressions. 
+The popular term "regex" is in the process of
+becoming a technical term with a precise meaning of: "something you do
+pattern matching with, kinda like a regular expression".
+
+One of the purposes of the Perl 6 redesign of I<regexen> (plural of I<regex>) 
+is to make portions of these patterns more amenable to analysis under traditional regular
+expression and parser semantics, and that involves making careful
+distinctions between which parts of Perl6 patterns and grammars are
+to be treated as declarative, and which parts as procedural.
+
+When referring to recursive patterns within a grammar,
+the terms I<rule> and I<token> are generally preferred over I<regex>.
+Chapter contents:
+	Overview
+	New match result and capture variables
+	Unchanged syntactic features
+	Simplified lexical parsing of patterns
+	Modifiers
+		Allowed modifiers
+	Changed metacharacters
+	New metacharacters
+	Bracket rationalization
+	Variable (non-)interpolation
+	Extensible metasyntax (C<< <...> >>)
+		Predefined Subrules
+	Backslash reform
+	Regexes constitute a first-class language, rather than just being strings
+	Backtracking control
+	Regex Routines, Named and Anonymous
+	Nothing is illegal
+	Longest-token matching
+	Return values from matches
+		Match objects
+		Subpattern captures
+		Accessing captured subpatterns
+		Nested subpattern captures
+		Quantified subpattern captures
+		Indirectly quantified subpattern captures
+		Subpattern numbering
+		Subrule captures
+		Accessing captured subrules
+		Repeated captures of the same subrule
+		Aliasing
+			Named scalar aliasing to subpatterns
+			Named scalar aliases applied to non-capturing brackets
+			Named scalar aliasing to subrules
+			Numbered scalar aliasing
+			Scalar aliases applied to quantified constructs
+			Array aliasing
+			Hash aliasing
+			External aliasing
+		Capturing from repeated matches
+	Grammars
+	Syntactic categories
+	Pragmas
+	Transliteration
+	Substitution
+	Positional matching, fixed width types
+	Matching against non-strings
+	When C<$/> is valid
+
+Synopsis 6: Subroutines
+S06 covers subroutines and the new type system.
+Chapter contents:
+	Subroutines and other code objects
+	Routine modifiers
+		Named subroutines
+		Anonymous subroutines
+		Perl5ish subroutine declarations
+		Blocks
+		"Pointy blocks"
+		Stub declarations
+		Globally scoped subroutines
+		Dynamically scoped subroutines
+		Lvalue subroutines
+		Parcel subroutines
+		Operator overloading
+	Calling conventions
+	Signatures
+	Parameters and arguments
+		Named arguments
+		Invocant parameters
+		Longname parameters
+		Required parameters
+		Optional parameters
+		Named parameters
+		List parameters
+		Slurpy block
+		Argument list binding
+		Parcel binding
+		Flattening argument lists
+		Multidimensional argument list binding
+		Zero-dimensional argument list
+		Feed operators
+		Closure parameters
+		En passant type capture
+		Unpacking array parameters
+		Unpacking a single list argument
+		Unpacking tree node parameters
+		Attributive parameters
+		Placeholder variables
+	Properties and traits
+		Subroutine traits
+		Parameter traits
+		Signature Introspection
+	Advanced subroutine features
+		Processing of returned values
+		The C<return> function
+		The C<callframe> and C<caller> functions
+		The C<want> function
+		The C<leave> function
+		Temporization
+		Wrapping
+		The C<&?ROUTINE> object
+		The C<&?BLOCK> object
+		Priming
+		Macros
+		Quasiquoting
+		Splicing
+	Other matters
+		Anonymous hashes vs blocks
+		Pairs as lvalues
+		Out-of-scope names
+		Declaring a C<MAIN> subroutine
+		Relationship of MAIN routine with lexical setting
+		Implementation note on autothreading of only subs
+		Introspection
+			Routine
+			Signature
+
+Synopsis 7: Lists and Iteration
+	Overview
+		The C<List> type
+		The C<Array> type
+		The C<Parcel> type
+		Flattening contexts, the C<Iterable> type
+		Iterators
+			The C<.reify> method
+			The C<.infinite> method
+		Levels of laziness
+		The laziness level of some common operations
+		Common list operations
+
+Synopsis 8: Capture and Parcel
+S08 deals with data captures for routines, such as subs.
+Chapter contents:
+	Introduction
+	Capture or Parcel
+	Multidimensionality
+	Context deferral
+	Additions
+
+Synopsis 9: Data Structures
+S09 discusses in detail the design of Perl 6 data structures.  It is
+primarily a discussion of how the existing features of Perl 6 combine
+to make it easier for the PDL folks to write numeric Perl.
+Chapter contents:
+	Lazy lists
+	Sized types
+	Compact structs
+	Standard array indexing
+	Fixed-size arrays
+	Typed arrays
+	Compact arrays
+	Multidimensional arrays
+		Autoextending multidimensional arrays
+	User-defined array indexing
+	Inclusive subscripts
+	Negative and differential subscripts
+	Mixing subscripts
+	PDL support
+	Subscript and slice notation
+	Cascaded subscripting of multidimensional arrays
+	The semicolon operator
+	PDL signatures
+	Autothreading types
+		Junctions
+		Each
+	Parallelized parameters and autothreading
+	Hashes
+	Autosorted hashes
+	Autovivification
+
+Synopsis 10: Packages
+S10 discusses packages as the basis of modules and classes.
+Chapter contents:
+	Packages
+	Package nesting
+	Autoloading
+
+Synopsis 11: Units and Modules
+S11 covers compilation units, such as grammars, modules and classes.
+Chapter contents:
+	Units
+	Modules
+	Exportation
+	Dynamic exportation
+	Compile-time Importation
+		Loading without importing
+		Importing without loading
+	Runtime Importation
+	Forcing Perl 6
+	Tool use vs language changes
+	CompUnitRepo
+		new
+		install
+		candidates
+	CompUnit
+		load
+
+Synopsis 12: Objects
+S13 discusses object-oriented programming.
+Chapter contents:
+	Classes
+		Class traits
+			Single inheritance
+			Multiple inheritance
+			Composition
+			The C<also> declarator
+		Metaclasses
+		Closed classes
+		Private classes
+		Class composition
+		Anonymous class declaration
+	Methods
+		Invocants
+		Private methods
+		Method scoping
+		Method calls
+			Fancy method calls
+		Lvalue methods
+		Scalar container indirection
+		FALLBACK methods
+	Class methods
+	Submethods
+	Attributes
+		Attribute default values
+		Class attributes
+	Construction and Initialization
+		Semantics of C<bless>
+		Cloning
+	Mutating methods
+	Calling sets of methods
+	Parallel dispatch
+	Multisubs and Multimethods
+		C<multi> Declarations
+		C<only> Declarations
+		C<proto> Declarations
+		C<proto> Signatures
+		C<multi> Variables
+		C<multi> Routines
+		Multisub Resolution
+			Candidate Tiebreaking
+			Parameter Constraint Exclusion
+			Constrained Type Candidates
+			Multi Submethods et Cetera
+		Method call vs. Subroutine call
+	Trusts
+	Delegation
+	Types and Subtypes
+		Abstract vs Concrete types
+		Multiple constraints
+	Enumerations
+		Value Generation
+		The Enumeration Type
+		Anonymous Enumerations
+		Composition from Pairs
+		Anonymous Mixin Roles using C<but> or C<does>
+		Adding Traits
+		Exporting
+		Implying a Role
+		Built-in Enumerations
+		Miscellaneous Rules
+		The C<.pick> Method
+	Open vs Closed Classes
+	Representations
+	Interface Consistency
+	Introspection
+	Custom Meta-objects
+	Autovivifying objects
+
+Synopsis 13: Overloading
+S13 discusses the Perl 6 multiple dispatch mechanism, which allows for an author to
+re-define operators and functions. The mechanism is called 'overloading' in Perl 5.
+Chapter contents:
+	Multiple dispatch
+	Syntax
+	Fallbacks
+	Type Casting
+
+Synopsis 14: Roles and Parametric Types
+S14 discusses roles and parametric types as the mechanisms for software reuse.
+Classes are used for object management.
+Chapter contents:
+	Roles
+		Compile-time Composition
+		Run-time Mixins
+	Traits
+	Parametric Roles
+		Relationship Between of And Types
+		Parametric Subtyping
+		Interaction of typed and untyped data structures
+S15 describes how Unicode and Perl 6 work together. Needless to say,
+it would be good for your chosen reader to support various Unicode characters.
+Chapter contents:
+	String Base Units
+	Normalization Forms
+		NFG
+		NFC and NFD
+		NFKC and NFKD
+	The C<Str> Type
+		Length Methods
+	The C<NF*> Types
+	The C<Uni> Type
+	The C<Unicodey> Role
+		Length Methods
+	The C<Stringy> Role
+	C<Buf> methods
+		Decoding buffers
+	Unicode Information
+		Information Hash
+		Numeric Codepoint
+		Character Representation
+		Character Name
+	Regexes
+		Grapheme Explosion
+	Quoting Constructs
+	Pragmas
+	Final Considerations
+
+Synopsis 16: IO / Name Services
+S16 deals with the syntax for bringing data into and pushing data out of
+a program from file systems.
+
+Many of these functions will work as in Perl 5, except that the code is 
+rationalized into roles.
+
+It can be assumed most of the important functions will automatically
+be in the * namespace.  However, with IO operations in particular,
+many of them are really methods on an IO handle, and if there is a
+corresponding global function, it's merely an exported version of
+the method.
+Chapter contents:
+	IO
+		Overridable IO handles
+		Roles and Classes
+		Special Quoting Syntax
+			Default constraints
+			:posix constraints
+			:portable
+			:local
+			:modern constraints
+			:win constraints
+			:unix constraints
+			:bin constraints (no constraints at all)
+			Other constraints
+		$*CWD
+		$*TMPDIR
+	Name Services
+		User role
+		OS::Unix::User role
+		Group role
+		OS::Unix::NameServices role
+	Additions
+
+Synopsis 17: Concurrency
+S17 is based around the concurrency primitives and tools currently
+being implemented in Rakudo on the JVM.  It covers both things that are
+already implemented today, in addition to things expected to be implemented
+in the near future (where "near" means O(months)).
+Chapter contents:
+	Design Philosophy
+		Focus on composability
+		Boundaries between synchronous and asynchronous should be explicit
+		Implicit parallelism is OK
+		Make the hard things possible
+	Schedulers
+	Promises
+	Channels
+	Supplies
+	The Event Loop
+		Threads
+		Atomic Compare and Swap
+	Locks
+
+Synopsis 19: Command Line Interface
+S19 describes the command line interface.
+It has changed extensively from previous versions of Perl in order to increase
+clarity, consistency, and extensibility. Many of the syntax revisions are
+extensions, so you'll find that much of the Perl 5 syntax embedded in your
+muscle memory will still work.
+Chapter contents:
+	Introduction
+	Command Line Elements
+	Backward (In)compatibility
+		Unchanged Syntactic Features
+		Removed Syntactic Features
+	Options and Values
+		Remaining arguments
+	Option Reference
+		Synopsis
+		Reference
+	Metasyntactic Options
+	Environment Variables
+	References
+	Notes
+
+Synopsis 21: Calling Foreign Code
+S19 is largely derived
+from Zavolaj: NativeCall as implemented for Rakudo at
+L<https://github.com/jnthn/zavolaj/>.
+Chapter contents:
+	SYNOPSIS
+	DESCRIPTION
+		Calling foreign code
+			The C<is native> trait
+			The C<is symbol> trait
+			The C<is nativeconv> trait
+			The C<is encoded> trait
+			Global variables
+		Marshalling and demarshalling of Perl 6 data
+			Numeric types
+			Strings
+			The C<OpaquePointer> class
+			The C<CPointer> REPR
+			The C<CArray> class
+			The C<CStruct> REPR
+			Callable objects
+			Complex data value types
+			Varargs
+		Miscellaneous helper functions
+			Refreshing outdated objects
+
+Synopsis 22: Package Format
+S22 specifies the format to be used for packages that are intended for public distribution.
+Chapter contents:
+	OVERVIEW
+		Terminology and Scope
+		Inspirations
+	PACKAGE LAYOUT
+		Project directory
+		.jib files
+	METADATA SPEC
+		Supported fields
+		Suggested fields[3]
+	DEPENDENCIES
+		Dependency Notation
+			Basic notation:
+			More complex examples:
+			Serialization Examples
+
+Synopsis 24: Testing
+S24 describes the way Perl 6 itself is tested.
+Chapter contents:
+	SYNOPSIS
+	DESCRIPTION
+		Test plans
+		Test functions
+		todo() and skip()
+S26 is about Perl 6 POD dialect
+Chapter contents:
+	
+		General syntactic structure
+		
+			Delimited blocks
+			Paragraph blocks
+			Abbreviated blocks
+			Declarator blocks
+			Block equivalence
+			Standard configuration options
+		Block types
+			Headings
+				Numbered headings
+			Ordinary paragraph blocks
+			Code blocks
+				Formatting within code blocks
+			I/O blocks
+			Lists
+				Ordered lists
+				Unordered lists
+				Multi-paragraph list items
+				Definition lists
+			Nesting blocks
+			Tables
+			Named blocks
+			Pod comments
+			The C<=finish> block
+			Data blocks
+			Semantic blocks
+		Formatting codes
+			Significance indicators
+			Definitions
+			Example specifiers
+			Verbatim text
+			Inline comments
+				Comments as category markers
+			Links
+			Placement links
+			Alias placements
+			Space-preserving text
+			Entities
+			Indexing terms
+			Annotations
+			Module-defined formatting codes
+		Encoding
+		Block pre-configuration
+			Pre-configuring formatting codes
+		Aliases
+			Macro aliases
+			Contextual aliases
+	How Pod is parsed and processed
+		Directives
+		Blocks
+		Formatting codes
+
+Synopsis 28 - Special Names
+S28 deals with special variables Perl6 creates by default for all programs.
+Chapter contents:
+	Special Variables
+		Introduction
+		Overview
+			Secondary Sigils (also known as "twigils")
+			Named variables
+			Perl5 to Perl6 special variable translation
+		NOT YET DEFINED
+			Form.pm
+			S15-unicode.pod
+			Infectious trait spec
+	Additions
+
+Synopsis 29: Builtin Functions
+S29 covers the functions Perl 6 provides by default to all programs.
+Chapter contents:
+	Notes
+		Operators vs. Functions
+		Multis vs. Functions
+	Type Declarations
+	Function Packages
+		Context
+		OS
+		Concurrency
+		Pending Apocalypse
+		Default Functions
+		Non-default Functions
+			Container
+			Numeric
+			IO
+			Temporal
+			String
+		Obsolete Functions
+			Keywords
+	Default Export Questions
+	Additions
+
+Synopsis 31: Pragmatic Modules
+S31 lists Perl 6 pragmas that are mentioned in other Synposes.
+Chapter contents:
+	Overview
+	Pragmata
+	Additions
+
+Synopsis 32: Setting Library - Basics
+S32::Basics covers the classes and roles underlying all other classes.
+Chapter contents:
+	Roles
+		Mu
+		Any
+		Pattern
+		Scalar
+	Additions
+
+Synopsis 32: Setting Library - Callable
+S32::Callable documents Code, Block, Signature, Capture, Routine, Sub, Method, Submethod,
+and Macro.
+Chapter contents:
+	Callable
+	Code
+	Block
+	Signature
+	Capture
+	WrapHandle
+	Routine
+	Sub
+	Method
+	Submethod
+	Macro
+	Additions
+
+Synopsis 32: Setting Library - Containers.pod
+S32::Containers covers roles that are associated with container types.
+Chapter contents:
+	Function Roles
+		Positional
+		Associative
+		List
+		Array
+		Hash
+	Classes and Roles
+		Range
+		Buf
+			Methods
+			C<Buf> Operators
+		Enum and Pair
+		EnumMap
+		PairMap
+		Set
+		SetHash
+		Bag
+		BagHash
+		QuantHash
+		MixHash
+		Junction
+	Additions
+
+Synopsis 32: Setting Library - Exceptions
+S32::Exceptions documents how errors and exceptions are handled in Perl 6.
+Chapter contents:
+	Roles and Classes
+		Exception
+		X::OS
+		X::IO
+			X::IO::Rename
+			X::IO::Copy
+			X::IO::Mkdir
+			X::IO::Chdir
+			X::IO::Dir
+			X::IO::Cwd
+			X::IO::Rmdir
+			X::IO::Unlink
+			X::IO::Chmod
+		X::NYI
+		X::AdHoc
+		Compile-time errors
+			X::Comp
+			X::Placeholder::Block
+			X::Placeholder::Mainline
+			X::Redeclaration
+			X::Undeclared
+			X::Attribute::Undeclared
+			X::Phaser::Multiple
+			X::Parameter::Default
+			X::Parameter::Placeholder
+			X::Parameter::Twigil
+			X::Parameter::MultipleTypeConstraints
+			X::Parameter::WrongOrder
+			X::Signature::NameClash
+			X::Method::Private::Permission
+			X::Method::Private::Unqualified
+			X::Bind::NativeType
+			X::Attribute::Package
+			X::Attribute::NoPackage
+			X::Value::Dynamic
+			X::Declaration::Scope
+			X::Declaration::Scope::Multi
+			X::Anon::Multi
+			X::Anon::Augment
+			X::Augment::NoSuchType
+			X::Package::Stubbed
+			X::Inheritance::Unsupported
+		Syntax Errors
+			X::Syntax
+			X::Syntax::Obsolete
+			X::Syntax::Name::Null
+			X::Syntax::UnlessElse
+			X::Syntax::Reserved
+			X::Syntax::P5
+			X::Syntax::NegatedPair
+			X::Syntax::Variable::Numeric
+			X::Syntax::Variable::Match
+			X::Syntax::Variable::Twigil
+			X::Syntax::Variable::IndirectDeclaration
+			X::Syntax::Augment::WithoutMonkeyTyping
+			X::Syntax::Augment::Role
+			X::Syntax::Placeholder
+			X::Syntax::Comment::Embedded
+			X::Syntax::Pod::BeginWithoutIdentifier
+			X::Syntax::Pod::BeginWithoutEnd
+			X::Syntax::Confused
+			X::Syntax::Malformed
+			X::Syntax::Missing
+			X::Syntax::SigilWithoutName
+			X::Syntax::Self::WithoutObject
+			X::Syntax::VirtualCall
+			X::Syntax::NoSelf
+			X::Syntax::Number::RadixOutOfRange
+			X::Syntax::Regex::Adverb
+			X::Syntax::Signature::InvocantMarker
+			X::Syntax::Extension::Category
+			X::Syntax::InfixInTermPosition
+		X::Pod
+		Dispatch errors
+			X::Method::NotFound
+			X::Method::InvalidQualifier
+		X::OutOfRange
+		X::Buf::AsStr
+		X::Buf::Pack
+		X::Buf::Pack::NonASCII
+		X::Bind
+		X::Bind::Slice
+		X::Bind::ZenSlice
+		X::Does::TypeObject
+		X::Role::Initialization
+		X::Routine::Unwrap
+		X::Constructor::Positional
+		X::Hash::Store::OddNumber
+		X::Phaser::PrePost
+		X::Str::Numeric
+		X::Str::Match::x
+		X::Str::Trans::IllegalKey
+		X::Str::Trans::InvalidArg
+		X::Range::InvalidArg
+		X::Sequence::Deduction
+		X::ControlFlow
+		X::ControlFlow::Return
+		X::Composition::NotComposable
+		X::TypeCheck
+		X::TypeCheck::Binding
+		X::TypeCheck::Return
+		X::NoDispatcher
+		X::Localizer::NoContainer
+		X::Mixin::NotComposable
+		X::Export::NameClash
+		X::HyperOp::NonDWIM
+		X::Set::Coerce
+		X::Temporal
+		X::Temporal::InvalidFormat
+		X::Temporal::Truncation
+		X::Eval::NoSuchLang
+		X::Numeric::Real
+	Related types
+		Failure
+		Backtrace
+	The Default Exception Printer
+
+Synopsis 32: Setting Library - IO
+S32::IO deals with the common IO operations for reading and writing files.
+Chapter contents:
+	Overview
+	Functions
+	IO Types
+		IO
+		IO::Handle
+		IO::FileTests
+		IO::Path
+			OS Specific subclasses.
+		IO::Spec
+	Here Be Dragons
+		IO::Socket
+		IO::Socket::INET
+	Conjectural Stuff
+		IO::ACL
+		IO::Pipe
+		OS-specific classes
+			Unix
+			Path::Unix
+			IO::Socket::Unix
+			IO::POSIX
+	Unfilled
+	Removed functions
+		IO::Buffered
+		IO::Streamable
+		IO::Encoded
+		IO::Readable::Encoded
+
+Synopsis 32: Setting Library - Numeric
+S32::Numeric documents Bit, Int, Numeric, Rat, Complex, and Bool.
+
+XXX So where are Bit, Int, and Rat
+Chapter contents:
+	Function Packages
+		Bool
+		Numeric
+		Real
+		Num
+		Complex
+		Trigonometric functions
+		Int
+		Rat
+	Additions
+
+Synopsis 32: Setting Library - Rules
+S32::Rules deals with objects produced by the regexes and grammars
+described in much greater detail in L<S05>.
+Chapter contents:
+	Classes
+		Regex
+		Match
+		Cursor
+		Grammar
+	Additions
+
+Synopsis 32: Setting Library - Str
+S32::Str covers the Perl 6 type for strings.
+Chapter contents:
+	Str
+	Additions
+
+Synopsis 32: Setting Library - Temporal
+S32::Temporal documents the Perl 6 mechanisms for including and handling
+time-related values into programs.
+Chapter contents:
+	Time and time again
+	C<time>
+	C<DateTime>
+		Accessors
+	C<Date>
+		Constructors
+		Instance methods
+		Arithmetics
+	FOOTNOTE
+
+Synopsis 99: Glossary
+S99 tries to define many of the terms used within the Perl 6
+community. It is intended as both a quick introduction to terms used on the #perl6
+channel (on freenode), as well as a more permanent, and deeper source of
+explanations in the context of Perl 6.
+
+If you, as a reader, miss a term in a glossary, just add the term with the
+explanation.  Or if you are not sure what the missing term means, just add a
+header for the term.  Without doubt, someone else more knowledgable will add
+the explanation later for you and everybody else.
+Chapter contents:
+	A
+		ack
+		actions
+		adverb
+		adverbial pair
+		AFAICS
+		AFAICT
+		AFAIK
+		afk
+		Any
+		any()
+		API
+		Apocalypse
+		array
+		AST
+		attribute
+		auth
+		author
+		authority
+		autopun
+	B
+		backlog
+		Bailador
+		blast
+		brb
+		BS
+	C
+		caller
+		CALLER::
+		Camelia
+		camelia
+		capture
+		CAS
+		circumfix
+		class
+		clog
+		CLR
+		compilation unit
+		compile time
+		compunit
+		concurrency
+		credentials
+	D
+		dalek
+		dead code
+		debugger
+		dev
+		dies_ok
+		DIHWIDT
+		dispatcher
+		distribution
+		dynamic
+	E
+		eager
+		ecosystem
+		edsel
+		EPIC FAIL
+		eval
+		Exegesis
+		export
+		EXPORT::
+	F
+		FAIL
+		fork
+		fossil
+		fudge
+	G
+		gimme
+		gist
+		git
+		git submodule
+		github
+		GLOBAL::
+		good *
+		grammar
+		green threads
+	H
+		hash
+		HPMoR
+		hyper
+	I
+		IC
+		IIRC
+		IIUC
+		import
+		infix
+		inline
+		install
+		installer
+		Int
+		int
+		interface
+		invocant
+		IRC
+		ISTR
+		item
+	J
+		jakudo
+		JAST
+		junction
+		JVM
+	K
+		karma
+		KISS
+	L
+		lazy
+		lexical
+		lexical pad
+		lexotic
+		LHF
+		lmddgtfy
+		LMGTFY
+		LTA
+		LTM
+	M
+		match
+		metamodel
+		method
+		MMD
+		MoarVM
+		module
+		MOP
+		MRO
+		Mu
+		multi
+		multi method
+		multi sub
+		multi-method dispatch
+		mumble
+		my
+		MY::
+	N
+		named parameter
+		namespace
+		need
+		NFG
+		Niecza
+		nom
+		null-PMC access
+		Num
+		number
+		NQP
+	O
+		our
+		OUR::
+		OUTER::
+	P
+		package
+		pad
+		Pair
+		pair notation
+		Panda
+		panda bootstrap script
+		parakudo
+		parrakudo
+		Parrot
+		parse
+		PAST
+		pb
+		PDD
+		Perlito
+		phaser
+		PIR
+		PMC
+		pod
+		pod6
+		Positional
+		positional parameter
+		postcircumfix
+		postfix
+		precedence
+		prefix
+		private
+		PROCESS::
+		producer
+		proto
+		PSGI
+		pull request
+		pugs
+		p5
+		p6
+	Q
+		QAST
+	R
+		race
+		Rakudo
+		Rakudo *
+		rakudobug
+		regex
+		regexp
+		reification
+		reify
+		REPL
+		repository
+		require
+		revert
+		roast
+		role
+		RPA
+		runtime
+	S
+		sanity test
+		scalar
+		segfault
+		segmentation fault
+		serialization
+		setting
+		sigil
+		sink context
+		sixplanet
+		slurpy
+		slushy
+		spectest
+		star
+		STM
+		Str
+		sub
+		subroutine
+		Synopsis
+	T
+		TheDamian
+		thinko
+		thread
+		TimToady
+		TIMTOWTDI
+		token
+		topic
+		trait
+		TTIAR
+		TMTOWTDI
+		tpyo
+		tuit
+		twigil
+	U
+		ufo
+		unit
+		UNIT::
+		unslushing
+	V
+		ver
+		VM
+		v5
+		v6
+	W
+		warnocked
+		WAT
+		wfm
+		whatever
+		whitespace
+		ww
+	X
+		XY Problem
+	Y
+		yoleaux
+	Z
+	*
+		.
+		..
+		...
+		:
+		?
+		*
+		@_
+		$_
+		%_
+		++
+		&

--- a/create_contents.p6
+++ b/create_contents.p6
@@ -1,0 +1,44 @@
+# Perl 6 program to create a contents.pod from all pod files in the directory
+
+my regex hs { ^\=head };
+my regex head { ^ \=head 
+  $<level>=(\d) 
+  $<label>=(.*?) $$
+  $<body>=( .* ) [\n]* <!before \= | . >  
+};
+my $str = '';
+my $lvl;
+my @opt;
+
+for (IO::Path.new('.').contents, IO::Path.new('S32-setting-library').contents).sort -> $f {
+  next unless $f ~~ m:i / .*\.pod /;
+  $f.basename.say;
+  for open($f).lines { 
+	if m/ <?hs> / {
+	  if $str ~~ m/ <head> / {
+		$str = "$<head><body>";
+		$lvl = +$<head><level>;
+		given $<head><label> {
+		  when m:i / TITLE / { 
+			@opt.push: '' if +@opt; 
+			@opt.push: trim($str) ; 
+			succeed 
+		  }
+		  when m:i / Document\ Description / { 
+			@opt.push: trim($str) ; 
+			@opt.push: "Chapter contents:" ;
+			succeed 
+		  }
+		  when m:i / AUTHORS | VERSION / { succeed }
+		  default { @opt.push: ("\t" x $lvl) ~ .trim }
+		}
+		$str = '';
+	  } else { 
+		$str =''
+	  }
+	}
+	$str ~= "$_\n"
+  }
+}
+
+spurt('contents.pod', join("\n",@opt) );


### PR DESCRIPTION
As suggested some time ago, I thought it would be useful to
a) unify the beginning of all the Synopses. Since various synopses use different start material headers, such as 
<no header>
"Overview"
"Introduction"

I added a new =head1 Document Description

b) Most Synopses have no Apocalypse ancestor, whilst where there is an ancestor, it is long long gone.

So I suggest rewriting to eliminate the history from all the Synopses, but the first.

c) I have rewritten the start of Synopsis 1

d) All these changes allow for a new contents.pod to be generated. A script to do this is included in this repo. Contents.pod is more a proof of concept file.

Apart from Synopsis 1, the revision have been relatively minor.
