### PR TITLE
--doc=html

### DIFF
--- a/S26-documentation.pod
+++ b/S26-documentation.pod
@@ -2791,7 +2791,7 @@ hint C<$?DOC> to true. If the K<--doc> flag is given a value, that value
 (with a C<but true> added) is placed in C<$?DOC>. This can be used to
 specify, for example, the output format desired:
 
-    perl --doc=html perldelta  > perldelta.html
+    perl --doc=HTML perldelta  > perldelta.html
 
 Under K<--doc>, the interpreter runs in a special mode, parsing the
 source code (including the Pod, as it always does) during compilation


### PR DESCRIPTION
There is no Pod::To::html but there is Pod::To::HTML. Anyway library is not part of the compiler so I'm not sure it is should be changed or not
