### PR TITLE
Edit glossary for typos etc.

### DIFF
--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -140,8 +140,8 @@ L<http://irc.perl6.org> to see what has been logged for you.
 
 Feature of a combinatorial algorithm which goes back one step toward the trunk
 after failing exploring a branch of the potential solution space.
-A string match is such a algorithm. Here, backtracking usually meains moving
-back the L</cursor>. In a non greedy match, it means moving the cursor forward.
+A string match is such an algorithm. Here, backtracking usually means moving
+back the L</cursor>. In a non-greedy match, it means moving the cursor forward.
 
 =head2 backend
 
@@ -154,7 +154,7 @@ is a port of Perl 5's Dancer web framework (L<http://perldancer.org/>).
 
 =head2 bare string
 
-An non quoted alphanumeric string. In Perl 6, only allowd at the left of a L</fat comma>.
+A non-quoted alphanumeric string. In Perl 6, only allowd at the left of a L</fat comma>.
 
 =head2 biab
 
@@ -251,7 +251,7 @@ The butterfly-like logo of Perl 6 as can be observed at L<http://perl6.org>.
 
 =head2 camelia
 
-The IRC-bot on #perl6 that will evaluate code for you in various version of
+The IRC-bot on #perl6 that will evaluate code for you in various versions of
 Perl 5, Perl 6 and NQP.
 
 =head2 capture
@@ -267,7 +267,7 @@ For example
         #   ^^ capture variable
     }
     
-C<(I<...>)> is the capture syntax while its non capturing counterpard is the grouping syntax : C<[I<...>]>.
+C<(I<...>)> is the capture syntax while its non-capturing counterpart is the grouping syntax : C<[I<...>]>.
 
 =head2 CAS
 
@@ -278,8 +278,8 @@ access.
 
 In L</grammar>s, regex of a L</multi> form a category that are distinguished
 by their L</longname>. That includes the L<signature> but also the value
-of the L<:sym> adverb. An L<expression|/Expression> is constituted of tokens that belongs
-either in the category L</term> or one of the L</operator>s categories.
+of the L<:sym> adverb. An L<expression|/Expression> consists of tokens that belong
+either in the category L</term> or one of the L</operator>'s categories.
 
 A regex definition for one of the term kinds :
 
@@ -302,7 +302,7 @@ splice will be very difficult for the end-user to notice in day-to-day use.
 
 =head2 circumfix
 
-If a syntactic construct, for example a pair of parenthesis, surrounds another
+If a syntactic construct, for example a pair of parentheses, surrounds another
 piece of syntax, the surrounding first part is called a circumfix.
 
     say (2 + 3);
@@ -343,8 +343,8 @@ Common Language Runtime, as used by Niecza/mono/.NET.
 
 =head2 comment
 
-Parts of a program intend for user consumption that are not used to generate code.
-Beside the C<#> that starts a comment that ends with the current line
+Parts of a program intended for user consumption that are not used to generate code.
+Beside the C<#> that starts a comment ending with the current line,
 Perl 6 supports many syntactic forms for different kinds of comments.
 Like inline comments that can be used as L</whitespace>, or comments
 that appear after a name declaration that are included in the L</pod>
@@ -359,17 +359,17 @@ It involves the L</serialization> of code and data.
 
 =head2 compiler
 
-In a L</dynamic language> like Perl 6, the compiler is also referred as L</interpreter>.
+In a L</dynamic language> like Perl 6, the compiler is also referred to as L</interpreter>.
 In simpler dynamic languages like
 Perl 5, the interpreter does not go through conceptual phases similar to the one for a compiler
-of non dynamic language, the term compiler is rarely used.
+of non-dynamic language, the term compiler is rarely used.
 
 When transforming L</concrete syntax> to L</bytecode>, the first conceptual phase is called L<parsing|/parse>
-and generate a L</parse tree>. Next the parse tree is transformed into an abstract syntax tree which is a form
-that can be optimised. Next the abstract tree is transformed to L</bytecode> in an L</compilation unit>.
-Then, this bytecode is executed. Depending on the type of the data manipulated by the L</program>
-bytecode can be transformed in optimised bytecode or into L</machine code>.
-This last two operations are forms of L</JIT>.
+and generates a L</parse tree>. Next the parse tree is transformed into an abstract syntax tree which is a form
+that can be optimised. Next the abstract tree is transformed to L</bytecode> in a L</compilation unit>.
+Then, this bytecode is executed. Depending on the type of the data manipulated by the L</program>,
+bytecode can be transformed into optimised bytecode or into L</machine code>.
+These last two operations are forms of L</JIT>.
 
 =head2 COMPILING::
 
@@ -388,7 +388,7 @@ See L</compilation unit>.
 
 =head2 concrete
 
-An L</object> L</value> is concrete when it is not the L</class> itself
+An L</object> L</value> is concrete when it is not the L</class> itself.
 
 =head2 concrete syntax
 
@@ -398,28 +398,28 @@ An L</object> L</value> is concrete when it is not the L</class> itself
 
 A context specifies the kind of value expected from an L<expression|/Expression>.
 A context may be L<boolean context|/boolean>, L<numeric context|/numeric>, L<item context|/item>,
-L<list context|/list> L<hash context|/hash>. 
-Some L</prefix> L</operator>s are used to force the context;  
+L<list context|/list> or L<hash context|/hash>. 
+Some L</prefix> L</operator>s are used to force the context.
 
 =head2 control flow
 
-Without control flow statements, a program execution would be purely sequential.
-Control flow statement generally uses a predicate and branches to one of its
-subtatement according to the predicate value.
+Without control flow statements, a program's execution would be purely sequential.
+A control flow statement generally uses a predicate and branches to one of its
+subtatements according to the predicate value.
 
 =head2 Control Flow Graph
 
-in L</spesh>, a L</dominance> graph generated from L</bytecode> analysis so that L</Single Static Assignment>
+In L</spesh>, a L</dominance> graph generated from L</bytecode> analysis so that L</Single Static Assignment>
 can be done.
 
 =head2 constant
 
-A L</variable> that has a unchangeable L</value>.
+A L</variable> that has an unchangeable L</value>.
 
 =head2 constructor
 
-The OO way to I<construct> object. L<Composer>s are constructor L</Huffmanization>s that are available for
-the most common types like L</pairs>s
+The OO way to I<construct> an object. L<Composer>s are constructor L</Huffmanization>s that are available for
+the most common types like L</pairs>s.
 
 =head2 CORE::
 
@@ -427,7 +427,7 @@ A L</pseudo-scope> to access L</symbol>s of the outermost lexical L</scope>, def
 
 =head2 CPAN
 
-Comprehensive Perl Archive Network.  Content delivery system for Perl
+Comprehensive Perl Archive Network.  A content delivery system for Perl
 distributions.
 
 =head2 credentials
@@ -533,7 +533,7 @@ See L</Control Flow Graph>
 
 =head2 DYNAMIC::
     
-A L</pseudo-scope> to access contextutal L</symbol>s  in my or any L</caller>'s lexical L</scope>.
+A L</pseudo-scope> to access contextutal L</symbol>s in my or any L</caller>'s lexical L</scope>.
 
 =head2 dynamic
 
@@ -666,7 +666,7 @@ L</runtime> exception.
 =head2 functional programming
 
 A programming style that mostly or exclusively relies on functions, L</pure> or not.
-Perl 6 support functionnal programming but does not force it on you.
+Perl 6 supports functional programming but does not force it on you.
 
 =head1 G
 
@@ -678,7 +678,7 @@ Garbage collecting.
 
 A B<gen>erated B<sym>bol. Used primarily in macro parlance, a gensym acts as a
 "handle" on something anonymous, allowing a macro author to refer to
-synthetically created bits of program after creating them. Gensyms generally
+synthetically created bits of a program after creating them. Gensyms generally
 look ugly, partly so as not to collide with anything else. The symbols
 `#:G847`, `#:G848` and `#:G850` below from
 L<http://lists.warhead.org.uk/pipermail/iwe/2005-July/000130.html> are gensyms:
@@ -718,7 +718,7 @@ The C<ecosystem> is hosted on github.
 
 =head2 given
 
-keyword for the Perl 6 switch L</statement>.
+Keyword for the Perl 6 switch L</statement>.
 
 =head2 GLOBAL::
 
@@ -792,7 +792,7 @@ Also, a given language may provide many flavors of them.
 Perl 6 provides common L</concrete syntax> to access them.
 C<MVMHLLConfig> is the L</MoarVM> C level structure that hooks
 to the underlying language specific representations.
-The L</metamodel> allows to express specific semantics proper to a given L</OO> language.
+The L</metamodel> allows expression of specific semantics proper to a given L</OO> language.
 L</Zavolaj> provides interoperabiity with languages which compilers
 follow C language linking conventions.
 
@@ -856,7 +856,7 @@ If I Understand Correctly.
 =head2 import
 
 L</Module>s interact with each other through named entities called symbols.
-The operation that makes symbols from a module avalaible to another
+The operation that makes symbols from a module available to another
 module is called import while the operation of using such a name is called import.
 
 =head2 infix
@@ -884,13 +884,13 @@ the L</source code> to generate L</object code> or L</bytecode>.
 In L</Rakudo> : L</parse tree>, and L<Abstract Syntax Tree|/AST>.
 The L</parser> generates a  that is transformeed to an L</AST>s
 Sometimes the information can be regenerated from the bytecode.
-In rakudo the Single Static Assignment form is inferred from the bytecode.
+In Rakudo the Single Static Assignment form is inferred from the bytecode.
 
 =head2 interpreter
 
 =head2 invocant
 
-A L</method> has generally one invocant by may have many according to its L</signature>.
+A L</method> has generally one invocant but may have many according to its L</signature>.
 As a L<parameter(s)>, the parameters before the C<;>. 
 As an L<argument>, the left L</operand> of the C<.> L</operator>.
 In the L<expression|/Expression> C<42.say>, C<42> is the invocant. 
@@ -898,7 +898,7 @@ When missing, like in C<.say>, the invocant is C<$_>.
 
 =head2 invokedynamic
 
-A L</opcode> that makes possible the support of C</dynamic language>s in L</JVM>.
+An L</opcode> that makes possible the support of C</dynamic language>s in L</JVM>.
 A L<presentation|http://www.infoq.com/presentations/invokedynamic> about invokedynamic.
 
 =head2 IR
@@ -921,7 +921,7 @@ I Seem To Remember.
 
 =head2 iteration
 
-A way to go thru all the values of an L</Iterable> object like a L</list> or a L</hash>.
+A way to go through all the values of an L</Iterable> object like a L</list> or a L</hash>.
 Generally, iterator L</object>s are invisible from user code because syntactical forms iterate
 for the user and pass the resulting value to the expression or the block acting on the value.
 Example:
@@ -946,7 +946,7 @@ Intermediate representation of code used in the JVM backend of Rakudo and NQP.
 =head2 JIT
 
 L<Just-in-time compilation|https://en.wikipedia.org/wiki/Just-in-time_compilation>,
-a technique for improving performance of virtual machines.
+a technique for improving the performance of virtual machines.
 
 =head2 Junction
 
@@ -955,8 +955,8 @@ L<http://doc.perl6.org/type/Junction>.
 
 =head2 JVM
 
-Java Virtual Machine. The Virtual machine for the Java programming language. Now many programming
-languages including Perl 6 have L</compilers> that targets the JVM.
+Java Virtual Machine. The virtual machine for the Java programming language. Now many programming
+languages including Perl 6 have L</compilers> targeting the JVM.
 
 =head1 K
 
@@ -1006,7 +1006,7 @@ from is a lexically defined routine.
 
 =head2 LGTM
 
-Looks good to me
+Looks good to me.
 
 =head2 LHF
 
@@ -1014,13 +1014,13 @@ Low Hanging Fruit.
 
 =head2 Library
 
-The compilation of a L</compilation unit> of source code written in non dynamic language like C
+The compilation of a L</compilation unit> of source code written in a non-dynamic language like C
 results in a library.
 
 =head2 LIFO
 
 L<Last In First Out|https://en.wikipedia.org/wiki/LIFO_(computing)>, a fairly common data structure in computer science.
-In Perl 6 arrays behave as such when used as L</stack>.  See also L</FIFO>.
+In Perl 6 arrays behave as such when used as a L</stack>.  See also L</FIFO>.
 
 =head2 List
 
@@ -1051,20 +1051,20 @@ Less Than Awesome.
 
 =head2 LTM
 
-See L<Longest Token Matching|http://design.perl6.org/S05.html#Longest-token_matching>
+See L<Longest Token Matching|http://design.perl6.org/S05.html#Longest-token_matching>.
 
 =head1 M
 
 =head2 machine code
 
-Code specific to the L</instruction set> of an hardware architecture. Compare with L</bytecode>.
+Code specific to the L</instruction set> of a hardware architecture. Compare with L</bytecode>.
 
 =head2 magic variable
 
 L</Variable> that has a behavior of its own and that is denoted by
 a sigiless name with a non alphanumeric character.
 Unlike Perl 5 that has a profusion of magic variables, Perl 6 includes only the 
-magic variables L</$_>, L</$/> and L<$!>. They are L</block> L</scope>d and implicitely
+magic variables L</$_>, L</$/> and L<$!>. They are L</block> L</scope>d and are implicitly
 defined at the beginning of each block.
 
 =head2 Match
@@ -1073,7 +1073,7 @@ L</Value> resulting from a L</match>.
 In L</list context>, gives the positional L</capture>s list.
 In L</hash context>, gives the named L</capture> hash.
 In L</numeric context>, gives the matched string length.
-In L</boolean context>, gives L</True> like any non class object.
+In L</boolean context>, gives L</True> like any non-class object.
 
 =head2 match
 
@@ -1086,18 +1086,18 @@ See also L</parse>.
 
 =head2 metamodel
 
-The metamodel describe some L<OO> behaviors, like where to find a L</method>.
-This permits to implement differnent OO behaviors in the same L</VM>.
+The metamodel describes some L<OO> behaviors, like where to find a L</method>.
+This permits implementation of different OO behaviors in the same L</VM>.
 The Perl 6 implementation of the metamodel is called L</6model>.
 The metamodel should not be confused with the L</representation>.
 
 =head2 method
 
-methods are L</sub>s that are called with an L</invocant>.
+Methods are L</sub>s that are called with an L</invocant>.
 
 =head2 MI
 
-Multiple inheritance
+Multiple inheritance.
 
 =head2 mischan
 
@@ -1123,7 +1123,7 @@ Meta-Object Protocol.
 
 =head2 MRO
 
-Method Resolution Order
+Method Resolution Order.
 
 =head2 Mu
 
@@ -1147,7 +1147,7 @@ Dynamically selecting which routine to execute based on name and type of argumen
 
 =head2 mumble
 
-Placeholder; Something that's left unclear deliberately. Either because the
+Placeholder; something that's left unclear deliberately. Either because the
 speaker doesn't know or because it's an unimportant detail.
 
 =head2 my
@@ -1166,7 +1166,7 @@ A L</pseudo-scope> to access L</symbol>s  in the current L</lexical scope> (aka 
 
 =head2 Native value
 
-A native value is a L</int>, L</num>, L</str>.
+A native value is an L</int>, L</num> or L</str>.
 A native value cannot be undefined.
 
 =head2 name
@@ -1314,7 +1314,6 @@ See L</lexical pad>.
 
 The simplest object containing a key and value pair.
 
-
 =head2 pair notation
 
 Way of expressing key/value pairs, using the L</fat comma>, creating a L</Pair>
@@ -1322,7 +1321,7 @@ object, for instance:
 
   foo => 1
 
-In contrast with the L</adverbial pair> notation.
+Compare with the L</adverbial pair> notation.
 
 =head2 Panda
 
@@ -1330,10 +1329,9 @@ A Perl 6 program designed to make it easier to download, compile and install L</
 according to the transitive dependencies specified in the C<META.info> medadata files
 of said modules.
 Unlike other L</package manager>s, panda supports many L</VM>s,
-that is the three VMs supported by the L</Rakudo> compiler: L</MoarVM>, L</Parrot> and L</JVM>.
+namely the three VMs supported by the L</Rakudo> compiler: L</MoarVM>, L</Parrot> and L</JVM>.
 The official set of modules is called the L</ecosystem> according to the L</github> repository
 name that contains the module list pointing to their respective repositories.
-
 
 =head2 panda bootstrap script
 
@@ -1345,7 +1343,7 @@ L</Rakudo> running on L</Parrot>.
 
 In a L</signature>, defines how the corresponding L</argument> is bound when the
 L</block>, L</sub> or L</method> with a signature is called.
-Is often designated as formal parameter in the literature about other languages.
+Is often designated as "formal parameter" in the literature about other languages.
 A parameter can be L</positional> or L</named>, either can be L</variadic> or not.
 
 =head2 parrakudo
@@ -1365,8 +1363,8 @@ A virtual machine designed to run Perl 6 and other L</dynamic language>s. Mostly
 The parser is the L</compiler> part that transforms the L</source code> into a L</parse tree>.
 A parser is specified by a L</grammar>.
 The code used by the parser leverages three different engines: the L<expression|/Expression> parser, a recursive engine,
-a L</NFA> based engine. L</LTM> is a feature of the L</NFA> engine. One difference between C<|> and C<||> is that the former
-involves a L</NFA>, while the latter involves the recursive engine. That's why the former is faster than the latter.
+an L</NFA> based engine. L</LTM> is a feature of the L</NFA> engine. One difference between C<|> and C<||> is that the former
+involves an L</NFA>, while the latter involves the recursive engine. That's why the former is faster than the latter.
 
 =head2 parse tree
 
@@ -1376,7 +1374,7 @@ Parrot L</AST>.
 
 =head2 PAUSE
 
-Perl Authors Upload SErvice.  The place where author upload their distributions
+Perl Authors Upload SErvice.  The place where authors upload their distributions
 to L</CPAN>.
 
 =head2 pb
@@ -1399,14 +1397,14 @@ about said feature.
 
 =head2 Perlito
 
-A L</compiler> project that has frontends for Perl 5 and Perl 6, and multiple
+A L</compiler> project that has frontends for Perl 5 and Perl 6, as well as multiple
 backends.
 
 =head2 phaser
 
 A piece of code (a L</blast>) that runs at a particular phase in the program's
 lifecycle, for example during L<compilation|/compiler> (C<BEGIN>), the first time a loop is
-entered (C<FIRST>), or after al regular code has run (C<END>).
+entered (C<FIRST>), or after all regular code has run (C<END>).
 
 =head2 PIO
 
@@ -1510,7 +1508,7 @@ A L</pseudo-scope> to access L</process>-related globals (superglobals) L</symbo
 
 =head2 PR
 
-short for L</pull request>
+Short for L</pull request>.
 
 =head2 PSA
 
@@ -1531,7 +1529,7 @@ through 2007.
 
 =head2 pure
 
-A function or method is pure if it has no side effect
+A function or method is pure if it has no side effect.
 
 =head2 p5
 
@@ -1604,19 +1602,19 @@ is finished.
 A repository contains the information pertaining to a software or its L</module>s.
 That is the source code, its history and ancillary information like a wiki, a bug tracking system,
 a static web site, depending on the hosting service containing the repository.
-Usuallly Perl 6 related information are stored in L</github> repositories.
-The official list of Perl 6 modules is the L</ecosystem> is also stored in a repository.
+Usually Perl 6 related information is stored in L</github> repositories.
+The official list of Perl 6 modules is the L</ecosystem> which is also stored in a repository.
 When installing a module, the L</panda> L</package manager> uses the ecosystem to
-fetch the appropriate repositories for transitive dependancies.
+fetch the appropriate repositories for transitive dependencies.
 
 =head2 REPR
 
-Representation
+Representation.
 
 =head2 Representation
 
-In MoarVM, low level C code associated to a data type. Typically a nqp call for a type translates
-into a moarvm instruction (opcode) that calls a function in the representation table of that type.
+In MoarVM, low level C code associated to a data type. Typically an NQP call for a type translates
+into a MoarVM instruction (opcode) that calls a function in the representation table of that type.
 
 =head2 require
 
@@ -1624,7 +1622,7 @@ into a moarvm instruction (opcode) that calls a function in the representation t
 
 =head2 roast
 
-The Perl 6 L<specification tests|/spectest>, which live here: L<https://github.com/perl6/roast/>
+The Perl 6 L<specification tests|/spectest>, which live here: L<https://github.com/perl6/roast/>.
 Originally developed for L</pugs>, it now serves all Perl 6 implementations.
 Why roast? It's the B<r>epository B<o>f B<a>ll B<s>pec B<t>ests.
 
@@ -1655,7 +1653,7 @@ before the actual release.
 
 See L<root object|http://en.wikipedia.org/wiki/Tracing_garbage_collection>.
 In L</MoarVM>, routines that handles roots are declared
-L<here|https://github.com/MoarVM/MoarVM/blob/master/src/gc/roots.h>
+L<here|https://github.com/MoarVM/MoarVM/blob/master/src/gc/roots.h>.
 
 =head2 Rosalind
 
@@ -1688,7 +1686,7 @@ fact that it doesn't work goes unnoticed.
 =head2 SC
 
 A L</serialization context> groups together things, usually from the same
-L</compilation Unit>
+L</compilation unit>.
 
 =head2 scalar
 
@@ -1708,7 +1706,7 @@ Something that should never, ever happen.  Complain on #perl6 if you see one.
 
 The serialization saves information obtained at compilation time from a L</compilation unit>
 to be deserialized at load time to perform various initialization tasks.
-The saved information  involves named constants, strings, among many other things.
+The saved information involves named constants, strings, among many other things.
 
 =head2 serialization context
 
@@ -1726,7 +1724,7 @@ When possible, the setting is loaded lazily to optimize loading time.
 =head2 shortname
 
 The name of a routine only; without the type signature of its invocant arguments.  
-See L</longname>
+See L</longname>.
 
 =head2 sigil
 
@@ -1734,13 +1732,13 @@ In Perl, the sigil is the first character of a variable name.
 It must be either C<$>, C<@>, C<%>, or C<&> respectively for a scalar,
 array, hash, or code variable.  See also L</twigil> and L</role>.
 Also sigilled variables allow short conventions for L<variable interpolation> in a double quoted string,
-or even C<postcircumfix> L<expression|/Expression> starting with such a variable.
+or even C<postcircumfix> L<expression|/Expression>s starting with such a variable.
 
 =head2 Single Static Assignment
 
 =head2 sink context
 
-L</Context> of an expression which value is ignored.
+L</Context> of an expression whose value is ignored.
 
 =head2 sixplanet
 
@@ -1774,8 +1772,8 @@ glass of ice water.
 =head2 spectest
 
 A program that passes the Perl 6 test suite is a valid Perl 6 L</compiler>.
-L<link|https://github.com/perl6/roast> to the L</github> L</repository> that contains
-the said test suit. See also: L</roast>.
+L<Link|https://github.com/perl6/roast> to the L</github> L</repository> that contains
+the said test suite. See also: L</roast>.
 
 =head2 spesh
 
@@ -1791,11 +1789,11 @@ See L</Single Static Assignment>.
 
 =head2 stack frame
 
-See L</frame>
+See L</frame>.
 
 =head2 STable
 
-Representation independent data structure associated to the
+Representation independent data structure associated with the
 type of an object. Part of the L</6model>.
 See L<http://jnthn.net/papers/2013-yapceu-moarvm.pdf>.
 
@@ -1813,7 +1811,7 @@ Data pertaining to a L</frame> gathered at compile time.
 
 =head2 STM
 
-Software Transactional Memory
+Software Transactional Memory.
 
 =head2 Str
 
@@ -1821,7 +1819,7 @@ Name of the string type.
 
 =head2 sub
 
-Short for subroutine
+Short for subroutine.
 
 =head2 Subroutine
 
@@ -1859,7 +1857,7 @@ and L<Exegeses|/Exegesis> were.
 
 =head2 Syntax sugar
 
-see L</Huffmanization>.
+See L</Huffmanization>.
 
 =head1 T
 
@@ -1892,7 +1890,7 @@ code to L</DWIM> or from an interrupted thought process.
 =head2 thread
 
 An execution unit more lightweight than a L</process>.
-Threads allow to parallelize code for concurrent performance
+Threads allow parallelization of code for concurrent performance
 but it is tricky to modify information shared by the different threads
 of a process.
 Perl 6 provides many primitives that create threads when needed so direct
@@ -1943,16 +1941,15 @@ Too Much Information.
 
 "There's More Than One Way To Do It", the Perl motto.
 
-
 =head2 token
 
 In L<parsing|/parser> theory, the parsed string is broken into tokens that are
 the input of L<syntax analysis>. In Perl 6, things are not so clear cut and the two
-conceptual phases are defined by the L</grammar>
+conceptual phases are defined by the L</grammar>.
 
 =head2 topic
 
-Expression which value is aliased to L<$_>
+Expression whose value is aliased to L<$_>.
 
 =head2 trait
 
@@ -1983,13 +1980,13 @@ See L<http://design.perl6.org/S02.html#Twigils>.
 
 Unicode Standard Annex.
 Unicode standard material that is not part of the core.
-Some are specific to some languages while other are generic,
-like L<UAX 15|http://www.unicode.org/reports/tr15/> that covers
+Some are specific to some languages while others are generic,
+like L<UAX 15|http://www.unicode.org/reports/tr15/> which covers
 L</Unicode Normalization Form>s.
 
 =head2 UCD
 
-See L</Unicode Character Database>
+See L</Unicode Character Database>.
 
 =head2 unboxing
 
@@ -2011,14 +2008,14 @@ See L<here|https://github.com/masak/ufo/>.
 =head2 unary
 
 An operator is unary if its L</arity> is one. Operators belonging to the L<categories|/category>
-L</prefix>, L</postfix>, L</circumfix> are unary.
+L</prefix>, L</postfix> and L</circumfix> are unary.
 
 =head2 Unicode
 
 Unicode is a standard defining the encodings, representation and handling of text in most writing systems.
 This standard includes a useful L<Unicode glossary|http://www.unicode.org/glossary/>.
 For Perl 6 handling of Unicode, see the 
-L<documentation|https://raw.githubusercontent.com/perl6/specs/master/S15-unicode.pod>
+L<documentation|https://raw.githubusercontent.com/perl6/specs/master/S15-unicode.pod>.
 See also L</NFG> for an encoding specific to Perl 6.
 
 =head2 Unicode Data Base
@@ -2038,7 +2035,7 @@ See L</compilation unit>.
 
 =head2 UNIT
     
-Symbols in the outermost lexical scope of compilation unit
+Symbols in the outermost lexical scope of a compilation unit.
 
 =head2 unslushing
 
@@ -2065,7 +2062,7 @@ Short way to indicate L</version>.
 =head2 version
 
 Can be obtained with C<I<perl6 -v>> with I<perl6> depending on your L</implementation>.
-This command gives something like below for L</Rakudo> on L</MoarVM>
+This command gives something like that below for L</Rakudo> on L</MoarVM>
 
   This is perl6 version 2014.08-187-gdf2245d built on MoarVM version 2014.08-55-ga5ae111
   
@@ -2103,7 +2100,7 @@ This lemma will never be explained.
 
 =head2 WAT
 
-L<https://www.destroyallsoftware.com/talks/wat>. Often used as the opposite of L</DWIM>
+L<https://www.destroyallsoftware.com/talks/wat>. Often used as the opposite of L</DWIM>.
 
 =head2 Weekly Changes
 
@@ -2133,7 +2130,7 @@ Work In Progress.
 
 =head2 WP
 
-Wikipedia
+Wikipedia.
 
 =head2 ww
 
@@ -2153,7 +2150,8 @@ problem.
 
 =head2 YAPAE
 
-Yet Another Potentially Awkward Explanation  See L<https://perl6advent.wordpress.com/2014/12/04/composers-coercers-and-the-case-of-a-camels-curious-corner/>
+Yet Another Potentially Awkward Explanation.
+See L<https://perl6advent.wordpress.com/2014/12/04/composers-coercers-and-the-case-of-a-camels-curious-corner/>.
 
 =head2 yoleaux
 

--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -561,7 +561,7 @@ yet in the end pleasing nobody, because nobody is catered for enough.
 
 =head2 empty list
 
-A list which contains no value. Noted C<()>.
+A list which contains no value. Denoted C<()>.
 
 =head2 EPIC FAIL
 
@@ -792,7 +792,7 @@ Also, a given language may provide many flavors of them.
 Perl 6 provides common L</concrete syntax> to access them.
 C<MVMHLLConfig> is the L</MoarVM> C level structure that hooks
 to the underlying language specific representations.
-The L</metamodel> allows expression of specific semantics proper to a given L</OO> language.
+The L</metamodel> allows one to express specific semantics proper to a given L</OO> language.
 L</Zavolaj> provides interoperabiity with languages which compilers
 follow C language linking conventions.
 
@@ -882,7 +882,7 @@ A built-in arbitrary-sized integer type. See L<http://doc.perl6.org/type/Int>.
 In a compiler, Intermediate data structures that are generated from
 the L</source code> to generate L</object code> or L</bytecode>.
 In L</Rakudo> : L</parse tree>, and L<Abstract Syntax Tree|/AST>.
-The L</parser> generates a  that is transformeed to an L</AST>s
+The L</parser> generates an IR that is transformed to an L</AST>.
 Sometimes the information can be regenerated from the bytecode.
 In Rakudo the Single Static Assignment form is inferred from the bytecode.
 
@@ -1196,7 +1196,7 @@ An implementation of Perl 6 targeting the .NET platform.
 
 =head2 Nil
 
-Means there is no value there which is different from C<()>, the L</empty list>.
+Means there is no value.  This is different from C<()>, the L</empty list>.
 
 =head2 NST
 
@@ -1268,17 +1268,17 @@ An expression is made of operators and operands. More precisely it is made of an
 operands that can be subexpressions or L</values>.
 Operators are an alternative syntax for a L<multi method>. With that syntax, what would be the L</argument>s of the function
 are named operands instead. Operators are classified into L<categories|http://design.perl6.org/S02.html#Grammatical_Categories> of categories.
-A category has a precedence, an arity, can be L</fidly>, L</iffy>, L</diffy>.
-Perl 6 is very creative as to what is an operator so they are many categories which operators are amde
-of many tokens, possibly with a subexpression.  For example,  L<@a[0]> belongs to the
-postcircumfix category is broken in the operand C<@a> and the
-postcircumfix operator L<[0]> where C<0> is postcircumfixed subexpression.
+A category has a precedence, an arity, and can be L</fidly>, L</iffy>, L</diffy>.
+Perl 6 is very creative as to what is an operator, so there are many categories.  Operators are made
+of many tokens, possibly with a subexpression.  For example, L<@a[0]> belongs to the
+postcircumfix category, is broken into the operand C<@a> and the
+postcircumfix operator L<[0]> where C<0> is the postcircumfixed subexpression.
 
 The C<< <O(I<...>)>  >> construction gives information about an operator that completes the
 information provided by its category.
-Below C<%conditional> is the category, C<< :reducecheck<ternary> >> specifies to call C<.ternary> to
-posprocess the L<parse subtree|parse tree> and C<< :pasttype<if> >> specify the nqp L</opcode> generated in the
-L</AST> from the parse subtree
+Below C<%conditional> is the category, C<< :reducecheck<ternary> >>, which specifies calling C<.ternary> to
+posprocess the L<parse subtree|parse tree> and C<< :pasttype<if> >> specifies the nqp L</opcode> generated in the
+L</AST> from the parse subtree.
 
         <O('%conditional, :reducecheck<ternary>, :pasttype<if>')>
 
@@ -1686,7 +1686,7 @@ fact that it doesn't work goes unnoticed.
 =head2 SC
 
 A L</serialization context> groups together things, usually from the same
-L</compilation unit>.
+L</compilation Unit>.
 
 =head2 scalar
 
@@ -1750,7 +1750,7 @@ If planeteria.org is down, a replacement can be found on L<http://pl6anet.org/>.
 Short for sublanguage. A slang is a L</grammar> derived from the Perl 6 grammar, and its associated L</actions>.
 Alternatively the Perl 6 syntax
 can be seen as the combination of many slangs (the regex slang, the quotation slang...)
-Defining a slang has a cost because it usually involves generating new L</NFA> tables but except for
+Defining a slang has a cost because it usually involves generating new L</NFA> tables; except for
 the space taken by the said tables, it is compilation time cost.
 Slang is a principled way to create Domain Specific Languages (DSLs).
 
@@ -2163,12 +2163,12 @@ See L<https://github.com/dpk/yoleaux> and L<http://dpk.io/yoleaux>.
 =head2 Zavolaj
 
 L</Zavolaj|https://github.com/jnthn/zavolaj> is a module to support C<native call>s
-into L<libraries|/library>
+into L<libraries|/library>.
 
 =head2 Zen slice
 
 A Zen slice is a slice of an object without specification of the elements.
-A such it is empty, yet it is supposed to return the object in its entirety.
+As such it is empty, yet it is supposed to return the object in its entirety.
 Usually used as a way of interpolating entire hashes / arrays in strings.
 
 =head1 *


### PR DESCRIPTION
These commits correct typos, minor grammatical errors and try to rewrite some sentences for better flow and meaning without changing the text's intent.  The two commits have been split into a "low risk" only typos, minor grammatical errors commit and a "higher risk" commit, containing textual changes which *could* change the original meaning of the text, but try very hard not to (the changes try to make correct sentences where possible and fill missing gaps with what seems to be the correct content).  Hence it might be wise to cherry pick the commits if they don't come up to par.

Comments most certainly welcome.