### PR TITLE
Resolve unresolved internal links in glossary

### DIFF
--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -96,7 +96,7 @@ L</Synopsis>.
 
 =head2 arity
 
-Number of L</operands> expected by an L</operator>.
+Number of L</operand>s expected by an L</operator>.
 
 =head2 argument
 
@@ -397,8 +397,8 @@ An L</object> L</value> is concrete when it is not the L</class> itself
 =head2 context
 
 A context specifies the kind of value expected from an L<expression|/Expression>.
-A context may be L<boolean context|/boolean>, L<numeric context|/numeric>, L<item context|/item>,
-L<list context|/list> L<hash context|/hash>. 
+A context may be L</boolean context>, L</numeric context>, L</item context>,
+L</list context> L</hash context>. 
 Some L</prefix> L</operator>s are used to force the context;  
 
 =head2 control flow
@@ -419,7 +419,7 @@ A L</variable> that has a unchangeable L</value>.
 =head2 constructor
 
 The OO way to I<construct> object. L<Composer>s are constructor L</Huffmanization>s that are available for
-the most common types like L</pairs>s
+the most common types like L</pair>s
 
 =head2 CORE::
 
@@ -781,6 +781,8 @@ A data type, conveniently available in variables starting with the percent sign
 C<%> and provided by types conformant to the C<Associative> role like the C<Hash> type.
 Often called associative table in other languages.
 
+=head2 hash context
+
 =head2 High Level Language
 
 A high level language provides abstractions that decouples it from specific operating systems
@@ -853,9 +855,11 @@ If I Remember Correctly.
 
 If I Understand Correctly.
 
+=head2 implementation
+
 =head2 import
 
-L</Module>s interact with each other through named entities called symbols.
+L<Module|/module>s interact with each other through named entities called symbols.
 The operation that makes symbols from a module avalaible to another
 module is called import while the operation of using such a name is called import.
 
@@ -888,10 +892,12 @@ In rakudo the Single Static Assignment form is inferred from the bytecode.
 
 =head2 interpreter
 
+=head2 instruction set
+
 =head2 invocant
 
 A L</method> has generally one invocant by may have many according to its L</signature>.
-As a L<parameter(s)>, the parameters before the C<;>. 
+As a L<parameter>(s), the parameters before the C<;>. 
 As an L<argument>, the left L</operand> of the C<.> L</operator>.
 In the L<expression|/Expression> C<42.say>, C<42> is the invocant. 
 When missing, like in C<.say>, the invocant is C<$_>.
@@ -918,6 +924,8 @@ I Seem To Remember.
 =head2 item
 
 =head2 item context
+
+=head2 Iterable
 
 =head2 iteration
 
@@ -998,6 +1006,10 @@ not from any information from run time.
 
 A data structure that holds the values of lexical variables.
 
+=head2 lexical scope
+
+=head2 lexical symbol
+
 =head2 lexotic
 
 A dynamic operation with a lexically scoped target. For example, C<return> has
@@ -1012,7 +1024,7 @@ Looks good to me
 
 Low Hanging Fruit.
 
-=head2 Library
+=head2 library
 
 The compilation of a L</compilation unit> of source code written in non dynamic language like C
 results in a library.
@@ -1023,6 +1035,8 @@ L<Last In First Out|https://en.wikipedia.org/wiki/LIFO_(computing)>, a fairly co
 In Perl 6 arrays behave as such when used as L</stack>.  See also L</FIFO>.
 
 =head2 List
+
+=head2 list context
 
 =head2 lmddgtfy
 
@@ -1083,6 +1097,8 @@ and returns an L</object> of L<Match> type in case of success, otherwise a L</Ni
 Matching against a C<regex> is a special case of L</smart match>ing.
 
 See also L</parse>.
+
+=head2 memory
 
 =head2 metamodel
 
@@ -1213,6 +1229,8 @@ Originally named so for its "new object model".
 
 =head2 number
 
+=head2 numeric context
+
 =head2 NQP
 
 Short for B<N>ot B<Q>uite B<P>erl, a subset of Perl 6 suitable for tasks such as
@@ -1224,14 +1242,14 @@ Native, Shaped Arrays.
 
 =head1 O
 
-=head2 Obfuscation
+=head2 obfuscation
 
 Code deliberately unreadable often using esoteric language features.
 Sometimes combined with L</Golfing>.
 
 =head2 object
 
-=head2 Object code
+=head2 object code
 
 For non L</dynamic languages>, from a L</compilation unit>, the L</compiler> generates
 object code or library. A latter phase links object code to generate an executable.
@@ -1266,7 +1284,7 @@ See L</operator>.
 
 An expression is made of operators and operands. More precisely it is made of an operator and
 operands that can be subexpressions or L</value>s.
-Operators are an alternative syntax for a L<multi method>. With that syntax, what would be the L</argument>s of the function
+Operators are an alternative syntax for a L</multi-method>. With that syntax, what would be the L</argument>s of the function
 are named operands instead. Operators are classified into L<categories|http://design.perl6.org/S02.html#Grammatical_Categories> of categories.
 A category has a precedence, an arity, can be L</fidly>, L</iffy>, L</diffy>.
 Perl 6 is very creative as to what is an operator so they are many categories which operators are amde
@@ -1277,7 +1295,7 @@ postcircumfix operator L<[0]> where C<0> is postcircumfixed subexpression.
 The C<< <O(I<...>)>  >> construction gives information about an operator that completes the
 information provided by its category.
 Below C<%conditional> is the category, C<< :reducecheck<ternary> >> specifies to call C<.ternary> to
-posprocess the L<parse subtree|parse tree> and C<< :pasttype<if> >> specify the nqp L</opcode> generated in the
+posprocess the L<parse subtree|/parse tree> and C<< :pasttype<if> >> specify the nqp L</opcode> generated in the
 L</AST> from the parse subtree
 
         <O('%conditional, :reducecheck<ternary>, :pasttype<if>')>
@@ -1285,6 +1303,10 @@ L</AST> from the parse subtree
 =head2 opt
 
 An optimization, usually in either the context of L</spesh> or L</JIT>.
+
+=head2 OS
+
+Operating system.  See L<http://en.wikipedia.org/wiki/Operating_system>.
 
 =head2 OSR
 
@@ -1501,6 +1523,8 @@ itself.
 A L</pseudo-scope> to access L</process>-related globals (superglobals) L</symbol>s.
 
 =head2 producer
+
+=head2 program
 
 =head2 pseudo-scope
 
@@ -2093,7 +2117,7 @@ This command gives something like below for L</Rakudo> on L</MoarVM>
 
   This is perl6 version 2014.08-187-gdf2245d built on MoarVM version 2014.08-55-ga5ae111
   
-Strangely the L</nqp> related information is missing.
+Strangely the L</NQP> related information is missing.
 
 =head2 Virtual Machine
 

--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -183,7 +183,7 @@ Used for L</control flow> and as L</scope>.
 
 =head2 Bool
 
-L</Boolean> type.
+L<Boolean|/boolean> type.
 
 =head2 boolean
 
@@ -235,6 +235,8 @@ For the user packages hosted on L</github>, you can report issues.
 =head2 bytecode
 
 =head1 C
+
+=head2 callable
 
 =head2 caller
 
@@ -378,7 +380,7 @@ A L</pseudo-scope> to access lexical L</symbol>s in the L</scope> being compiled
 =head2 composer
 
 A composer is a syntax for defining L</value>s. When values are L</object>s, their composer is a L</Huffmanization>
-of a L</constructor> L<expression|/Expression>. For an example, see the L</Fat comma>.
+of a L</constructor> L<expression|/Expression>. For an example, see the L</fat comma>.
 
 =head2 compunit
 
@@ -440,6 +442,8 @@ Short for C<CompUnitRepo>, the type of objects that inhabit C<@*INC>.
 
 Short for C<CompUnitRepo::Local>, the type of C<CompUnitRepo> objects that
 refer to the local file system.
+
+=head2 cursor
 
 =head1 D
 
@@ -516,7 +520,7 @@ from a remote location.
 
 =head2 DSL
 
-L</Domain Specific Language>. See L</slang>.
+L</Domain specific language>. See L</slang>.
 
 =head2 Domain specific language
 
@@ -527,7 +531,7 @@ rather than lower level details of parsing HTTP requests and generating
 HTTP responses. See also
 L<https://en.wikipedia.org/wiki/Domain-specific_language>
 
-=head2 Dominance
+=head2 dominance
 
 See L</Control Flow Graph>
 
@@ -648,6 +652,8 @@ not yet been fixed by correcting or removing it.
 
 Short for L</functional programming>
 
+=head2 frame
+
 =head2 FSVO
 
 For Some Value Of.
@@ -660,7 +666,7 @@ Fixed That For You.
 
 Way to temporarily mark tests in the L</spectest> for a specific Perl 6 version
 as I<todo> (so that a failure of the test will be marked ok, and a pass will
-be marked as an exception), or as I<skip> if they cause a L</compile-time> or
+be marked as an exception), or as I<skip> if they cause a L</compile time> or
 L</runtime> exception.
 
 =head2 functional programming
@@ -772,6 +778,11 @@ C<rule> implies L</whitespace>s between subrules.
 
 Threads that are scheduled by the virtual machine, not by the operating
 system.
+
+=head2 grep
+
+Command line utility to search text for lines matching a L</regex>.  See
+L<http://en.wikipedia.org/wiki/Grep>.
 
 =head1 H
 
@@ -964,7 +975,7 @@ L<http://doc.perl6.org/type/Junction>.
 =head2 JVM
 
 Java Virtual Machine. The Virtual machine for the Java programming language. Now many programming
-languages including Perl 6 have L</compilers> that targets the JVM.
+languages including Perl 6 have L</compiler>s that targets the JVM.
 
 =head1 K
 
@@ -1245,20 +1256,20 @@ Native, Shaped Arrays.
 =head2 obfuscation
 
 Code deliberately unreadable often using esoteric language features.
-Sometimes combined with L</Golfing>.
+Sometimes combined with L</golfing>.
 
 =head2 object
 
 =head2 object code
 
-For non L</dynamic languages>, from a L</compilation unit>, the L</compiler> generates
+For non L</dynamic language>s, from a L</compilation unit>, the L</compiler> generates
 object code or library. A latter phase links object code to generate an executable.
 For dynamic languages like Perl 6, the equivalent of object code is the L</bytecode> and
 the linking phase is more complex and involves the deL</serialization> of information.
 
 =head2 On Stack Replacement
 
-According to the hotspot L</glossary|http://openjdk.java.net/groups/hotspot/docs/HotSpotGlossary.html> :  The process of converting
+According to the hotspot L<glossary|http://openjdk.java.net/groups/hotspot/docs/HotSpotGlossary.html> :  The process of converting
 an interpreted (or less optimized) L</stack frame> into a compiled (or more optimized) stack frame.
 
 =head2 OO
@@ -1286,11 +1297,11 @@ An expression is made of operators and operands. More precisely it is made of an
 operands that can be subexpressions or L</value>s.
 Operators are an alternative syntax for a L</multi-method>. With that syntax, what would be the L</argument>s of the function
 are named operands instead. Operators are classified into L<categories|http://design.perl6.org/S02.html#Grammatical_Categories> of categories.
-A category has a precedence, an arity, can be L</fidly>, L</iffy>, L</diffy>.
+A category has a precedence, an arity, can be L</fiddly>, L</iffy>, L</diffy>.
 Perl 6 is very creative as to what is an operator so they are many categories which operators are amde
-of many tokens, possibly with a subexpression.  For example,  L<@a[0]> belongs to the
+of many tokens, possibly with a subexpression.  For example, C<@a[0]> belongs to the
 postcircumfix category is broken in the operand C<@a> and the
-postcircumfix operator L<[0]> where C<0> is postcircumfixed subexpression.
+postcircumfix operator C<[0]> where C<0> is postcircumfixed subexpression.
 
 The C<< <O(I<...>)>  >> construction gives information about an operator that completes the
 information provided by its category.
@@ -1720,7 +1731,7 @@ fact that it doesn't work goes unnoticed.
 =head2 SC
 
 A L</serialization context> groups together things, usually from the same
-L</compilation Unit>
+L</compilation unit>
 
 =head2 scalar
 
@@ -1776,7 +1787,7 @@ or even C<postcircumfix> L<expression|/Expression> starting with such a variable
 
 =head2 sink context
 
-L</Context> of an expression which value is ignored.
+L<Context|/context> of an expression which value is ignored.
 
 =head2 sixplanet
 
@@ -2241,7 +2252,7 @@ Everybody wants the colon.
     
 =head3 ()
 
-L</Empty List>
+See L</empty list>.
 
 =head2 *
 
@@ -2255,6 +2266,10 @@ Something you should stop using, and use subroutine signatures instead.
 The "topic variable". Set by any construct that's a "topicalizer", like the
 L</given> statement or a for loop.
 
+=head2 $/
+
+=head2 $!
+
 =head2 %_
 
 =head2 ++
@@ -2263,7 +2278,7 @@ Way to increase L</karma> on IRC.
 
 =head2 &
 
-L<Sigil|/sigil> of a L</Callable> L</variable>.  Also used at the end of a line in an L</IRC>
+L<Sigil|/sigil> of a L</callable> L</variable>.  Also used at the end of a line in an L</IRC>
 message to indicate the user is away, doing something else in the background.
 For instance:
 

--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -198,7 +198,7 @@ a negation.
 The L</predicate> part of a L</control flow> L</statement> forces a boolean context.
 A class can define a C<Bool> method to handle the boolean context.
 For L<natives|/"Native value">, within L</MoarVM>, it is handled by C</MVMBoolificationSpec> member
-of the L</stable> structure.
+of the L</STable> structure.
 
 =head2 bootstrap
 
@@ -278,7 +278,7 @@ access.
 
 In L</grammar>s, regex of a L</multi> form a category that are distinguished
 by their L</longname>. That includes the L<signature> but also the value
-of the L<:sym> adverb. An L<expression|/Expression> is constituted of tokens that belongs
+of the L</:sym> adverb. An L<expression|/Expression> is constituted of tokens that belongs
 either in the category L</term> or one of the L</operator>s categories.
 
 A regex definition for one of the term kinds :
@@ -1073,14 +1073,14 @@ L</Value|value> resulting from a L</match>.
 In L</list context>, gives the positional L</capture>s list.
 In L</hash context>, gives the named L</capture> hash.
 In L</numeric context>, gives the matched string length.
-In L</boolean context>, gives L</True> like any non class object.
+In L</boolean context>, gives C<True> like any non class object.
 
 =head2 match
 
 A match is an operation that tests a L</string> against a L</grammar> or a L</regex>.
 and returns an L</object> of L<Match> type in case of success, otherwise a L</Nil>
 
-Matching against a C<regex> is a special case of L</smartmatching>.
+Matching against a C<regex> is a special case of L</smart match>ing.
 
 See also L</parse>.
 
@@ -1166,7 +1166,7 @@ A L</pseudo-scope> to access L</symbol>s  in the current L</lexical scope> (aka 
 
 =head2 Native value
 
-A native value is a L</int>, L</num>, L</str>.
+A native value is a L</Int>, L</Num>, L</Str>.
 A native value cannot be undefined.
 
 =head2 name
@@ -1424,7 +1424,7 @@ Parrot Magic Cookie.
 =head2 pod
 
 B<P>lain B<O>l' B<D>ocumentation, a documentation format understood by Perl
-6. See L</S26> for details.
+6. See L<S26|http://design.perl6.org/S26.html> for details.
 
 =head2 pod6
 
@@ -1547,6 +1547,8 @@ Short for Perl 6, the (spunky little sister|child) of Perl 5.
 
 Successor to L</PAST>.
 
+=head2 queue
+
 =head1 R
 
 =head2 race
@@ -1571,6 +1573,8 @@ See L</Rakudo *>.
 =head2 rakudobug
 
 A bug in L</Rakudo>.  Usually used in contexts such as "/me submits rakudobug".
+
+=head2 range
 
 =head2 regex
 
@@ -1613,7 +1617,7 @@ fetch the appropriate repositories for transitive dependancies.
 
 Representation
 
-=head2 Representation
+=head2 representation
 
 In MoarVM, low level C code associated to a data type. Typically a nqp call for a type translates
 into a moarvm instruction (opcode) that calls a function in the representation table of that type.
@@ -1676,6 +1680,8 @@ Real Soon Now.
 Request Tracker (L<http://rt.perl.org/>).  To open a ticket, email
 C<rakudobug@perl.org>.
 
+=head2 rule
+
 =head2 runtime
 
 =head1 S
@@ -1684,6 +1690,8 @@ C<rakudobug@perl.org>.
 
 A test for a basic feature that robs your sanity if it doesn't work, and the
 fact that it doesn't work goes unnoticed.
+
+=head2 say
 
 =head2 SC
 
@@ -1703,6 +1711,8 @@ See L</segmentation fault>.
 =head2 segmentation fault
 
 Something that should never, ever happen.  Complain on #perl6 if you see one.
+
+=head2 semicolon
 
 =head2 serialization
 
@@ -1735,6 +1745,8 @@ It must be either C<$>, C<@>, C<%>, or C<&> respectively for a scalar,
 array, hash, or code variable.  See also L</twigil> and L</role>.
 Also sigilled variables allow short conventions for L<variable interpolation> in a double quoted string,
 or even C<postcircumfix> L<expression|/Expression> starting with such a variable.
+
+=head2 signature
 
 =head2 Single Static Assignment
 
@@ -1819,6 +1831,8 @@ Software Transactional Memory
 
 Name of the string type.
 
+=head2 string
+
 =head2 sub
 
 Short for subroutine
@@ -1851,11 +1865,15 @@ be it in the L</OS> level, or at the Perl 6 L</VM> level for modules generated f
 languages targeting these VMs.
 The set of imported or exported symbols is called the symbol table.
 
+=head2 :sym
+
 =head2 Synopsis
 
 The current human-readable description of the Perl 6 language.  Still in
 development.  Much more a community effort than the L</Apocalypse>s
 and L<Exegeses|/Exegesis> were.
+
+=head2 Syntax analysis
 
 =head2 Syntax sugar
 
@@ -1866,6 +1884,8 @@ see L</Huffmanization>.
 =head2 TAP
 
 L<Test Anything Protocol|http://en.wikipedia.org/wiki/Test_Anything_Protocol>
+
+=head2 term
 
 =head2 Texas operator
 
@@ -1947,7 +1967,7 @@ Too Much Information.
 =head2 token
 
 In L<parsing|/parser> theory, the parsed string is broken into tokens that are
-the input of L<syntax analysis>. In Perl 6, things are not so clear cut and the two
+the input of L<syntax analysis|/Syntax analysis>. In Perl 6, things are not so clear cut and the two
 conceptual phases are defined by the L</grammar>
 
 =head2 topic
@@ -1976,6 +1996,8 @@ A secondary L</sigil>. For example, C<%*ENV> has a sigil of C<%> and
 a twigil of C<*>.
 
 See L<http://design.perl6.org/S02.html#Twigils>.
+
+=head2 type
 
 =head1 U
 

--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -187,7 +187,7 @@ L</Boolean> type.
 
 =head2 boolean
 
-L</Value> of type L</Bool>. Apart the class itself, can be either C<True> or C<False>.
+L<Value|/value> of type L</Bool>. Apart the class itself, can be either C<True> or C<False>.
 
 =head2 boolean context
 
@@ -377,7 +377,7 @@ A L</pseudo-scope> to access lexical L</symbol>s in the L</scope> being compiled
 
 =head2 composer
 
-A composer is a syntax for defining L</values>. When values are L</object>s, their composer is a L</Huffmanization>
+A composer is a syntax for defining L</value>s. When values are L</object>s, their composer is a L</Huffmanization>
 of a L</constructor> L<expression|/Expression>. For an example, see the L</Fat comma>.
 
 =head2 compunit
@@ -1061,7 +1061,7 @@ Code specific to the L</instruction set> of an hardware architecture. Compare wi
 
 =head2 magic variable
 
-L</Variable> that has a behavior of its own and that is denoted by
+L</Variable|variable> that has a behavior of its own and that is denoted by
 a sigiless name with a non alphanumeric character.
 Unlike Perl 5 that has a profusion of magic variables, Perl 6 includes only the 
 magic variables L</$_>, L</$/> and L<$!>. They are L</block> L</scope>d and implicitely
@@ -1069,7 +1069,7 @@ defined at the beginning of each block.
 
 =head2 Match
 
-L</Value> resulting from a L</match>.
+L</Value|value> resulting from a L</match>.
 In L</list context>, gives the positional L</capture>s list.
 In L</hash context>, gives the named L</capture> hash.
 In L</numeric context>, gives the matched string length.
@@ -1184,7 +1184,7 @@ regex engine.  See: L<https://en.wikipedia.org/wiki/Nondeterministic_finite_auto
 
 =head2 NFG
 
-Proposed L</Unicode normalization form> for Perl6, in which composed
+Proposed L</Unicode Normalization Form> for Perl6, in which composed
 characters always get their own codepoint. If a codepoint doesn't exist
 for that composed character, one is assigned dynamically.
 
@@ -1265,7 +1265,7 @@ See L</operator>.
 =head2 operator
 
 An expression is made of operators and operands. More precisely it is made of an operator and
-operands that can be subexpressions or L</values>.
+operands that can be subexpressions or L</value>s.
 Operators are an alternative syntax for a L<multi method>. With that syntax, what would be the L</argument>s of the function
 are named operands instead. Operators are classified into L<categories|http://design.perl6.org/S02.html#Grammatical_Categories> of categories.
 A category has a precedence, an arity, can be L</fidly>, L</iffy>, L</diffy>.
@@ -2021,7 +2021,7 @@ For Perl 6 handling of Unicode, see the
 L<documentation|https://raw.githubusercontent.com/perl6/specs/master/S15-unicode.pod>
 See also L</NFG> for an encoding specific to Perl 6.
 
-=head2 Unicode Data Base
+=head2 Unicode Character Database
 
 It consists of a number of data files listing Unicode character properties and related data.
 It also includes data files containing test data for conformance to several important Unicode algorithms.
@@ -2057,6 +2057,8 @@ A variable is a name for a L</container>.
 =head2 variable interpolation
 
 See L</sigil> and L<S02/Q forms>.
+
+=head2 variadic
 
 =head2 ver
 
@@ -2164,7 +2166,7 @@ See L<https://github.com/dpk/yoleaux> and L<http://dpk.io/yoleaux>.
 
 =head2 Zavolaj
 
-L</Zavolaj|https://github.com/jnthn/zavolaj> is a module to support C<native call>s
+L<Zavolaj|https://github.com/jnthn/zavolaj> is a module to support C<native call>s
 into L<libraries|/library>
 
 =head2 Zen slice


### PR DESCRIPTION
These changes correct the issue of unresolved links in the `S99-glossary.pod` document.