### PR TITLE
Removing whitespace-only lines in glossary

### DIFF
--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -266,7 +266,7 @@ For example
         say $0;
         #   ^^ capture variable
     }
-    
+
 C<(I<...>)> is the capture syntax while its non capturing counterpard is the grouping syntax : C<[I<...>]>.
 
 =head2 CAS
@@ -532,7 +532,7 @@ L<https://en.wikipedia.org/wiki/Domain-specific_language>
 See L</Control Flow Graph>
 
 =head2 DYNAMIC::
-    
+
 A L</pseudo-scope> to access contextutal L</symbol>s  in my or any L</caller>'s lexical L</scope>.
 
 =head2 dynamic
@@ -604,7 +604,7 @@ Used to support L</opcode>s specific to a language.
 Contrary to Perl 5, C<< => >>, the fat comma does not simply separate two values but makes
 a L</Pair> out of them. The left value can be a L</bare string>. This is the only
 place where Perl 6 accepts a bare string. Example:
-    
+
       foo => bar
 
 =head2 fiddly
@@ -1153,7 +1153,7 @@ speaker doesn't know or because it's an unimportant detail.
 =head2 my
 
 =head2 MY::
-    
+
 A L</pseudo-scope> to access L</symbol>s  in the current L</lexical scope> (aka $?SCOPE).
 
 =head1 N
@@ -1293,7 +1293,7 @@ L</On Stack Replacement>
 =head2 our
 
 =head2 OUR::
-    
+
 A L</pseudo-scope> to access L</symbol>s in the current package (aka $?PACKAGE).
 
 =head2 OUTER::
@@ -1353,7 +1353,7 @@ A parameter can be L</positional> or L</named>, either can be L</variadic> or no
 See L</parakudo>.
 
 =head2 PARENT::
-    
+
 A L</pseudo-scope> to access lexical L</symbol>s in the unit's L<DSL> (usually L<CORE|/CORE::>).
 
 =head2 Parrot
@@ -2037,7 +2037,7 @@ Perl 6 defines an addtional one : L</NFG>.
 See L</compilation unit>.
 
 =head2 UNIT
-    
+
 Symbols in the outermost lexical scope of compilation unit
 
 =head2 unslushing
@@ -2068,7 +2068,7 @@ Can be obtained with C<I<perl6 -v>> with I<perl6> depending on your L</implement
 This command gives something like below for L</Rakudo> on L</MoarVM>
 
   This is perl6 version 2014.08-187-gdf2245d built on MoarVM version 2014.08-55-ga5ae111
-  
+
 Strangely the L</nqp> related information is missing.
 
 =head2 Virtual Machine
@@ -2190,7 +2190,7 @@ Everybody wants the colon.
 =head2 ?
 
 =head2 (
-    
+
 =head3 ()
 
 L</Empty List>


### PR DESCRIPTION
This issue was causing `podchecker` to emit the following warning in `S99-glossary.pod`:

    WARNING: line containing nothing but whitespace in paragraph

which has been corrected by this commit.