### PR TITLE
Add :createonly to valid named parameters for open()

### DIFF
--- a/S32-setting-library/IO.pod
+++ b/S32-setting-library/IO.pod
@@ -78,6 +78,7 @@ X<open()>
       # newlines
         Any  :$nl    = "EOL",
         Bool :$chomp = True,
+        Bool :$createonly = False,
         --> IO::Handle ) is export
 
 A convenience function for opening normal files as text (by default) as
@@ -132,6 +133,12 @@ C<"\r\n"> or C<"\r"> or any other Unicode character that has the C<Zl>
 
 Whether or not to remove new line characters from text obtained with
 C<.lines> and C<.get>.  Defaults to C<True>.
+
+=item :createonly
+
+Whether or not to fail if the given file already exists.  Only makes
+sense if the file is opened with C<:w>, C<:rw>, or C<:a>.  Defaults to
+C<False>.
 
 =back
 


### PR DESCRIPTION
I would like to propose a new named parameter for `open`, namely `:createonly`.  `rename`, `copy`, and `move` already support it, so I think it's only natural that `open` does as well.
