### PR TITLE
runout and shellout, no more :x

### DIFF
--- a/S02-bits.pod
+++ b/S02-bits.pod
@@ -3820,14 +3820,10 @@ a single short form adverb, which produces forms like:
 
     qw /a b c/;                         # P5-esque qw// meaning q:w
     Qc '...{$x}...';                    # Q:c//, interpolate only closures
-    qqx/$cmd @args[]/                   # equivalent to P5's qx//
-
-(Note that C<qx//> doesn't interpolate.)
 
 If you want to abbreviate further, just define a macro:
 
-    macro qx { 'qq:x ' }          # equivalent to P5's qx//
-    macro qTO { 'qq:x:w:to ' }    # qq:x:w:to//
+    macro qTO { 'qq:w:to ' }    # qq:w:to//
     macro quote:<❰ ❱> ($text) { quasi { {{{$text}}}.quoteharder } }
 
 All the uppercase adverbs are reserved for user-defined quotes.  All Unicode

--- a/S15-unicode.pod
+++ b/S15-unicode.pod
@@ -590,7 +590,7 @@ Various adverbs may be used to generate non-NFG literals:
 
     Q:nfd/NFD literal/
     qq:nfc:to/heredocIsNFC/
-    qx:nfkd/useful for commands on less capable terminals perhaps/
+    q:nfkd/useful for commands on less capable terminals perhaps/
 
 The typical C<:nf> adverbs are in use here.
 

--- a/S17-concurrency.pod
+++ b/S17-concurrency.pod
@@ -738,7 +738,7 @@ It can also take C<done> and C<quit> named parameters; these go to the tap, whil
 
 =head1 Inter-Process Communication exposed as Promises and Supplies
 
-Starting external processes is rather easy: C<shell()>, C<run()> and C<qx//>. Having external processes run asynchronously, is slightly more involved. But not much.  The workhorse of asynchronous IPC in Perl 6 is C<Proc::Async>:
+Starting external processes is rather easy: C<run()>, C<runout()>, C<shell()> and C<shellout>. Having external processes run asynchronously, is slightly more involved. But not much.  The workhorse of asynchronous IPC in Perl 6 is C<Proc::Async>:
 
     my $proc = Proc::Async.new( $path, @args );
 

--- a/S26-documentation.pod
+++ b/S26-documentation.pod
@@ -1553,7 +1553,7 @@ nestable block comments in Perl 6:
 =begin code
     =begin comment
     for @files -> $file {
-        shell("rm -rf $file");
+        run('rm', '-rf', $file);
     }
     =end comment
 =end code

--- a/S29-functions.pod
+++ b/S29-functions.pod
@@ -521,10 +521,10 @@ signal at all, and is used to determine if processes are still running:
 =item shell
 
 
- multi shell ( $expression,   :$cwd = $CWD, :%env = %*ENV --> Proc::Status )
  multi run   ( *$cmd, *@args, :$cwd = $CWD, :%env = %*ENV --> Proc::Status )
+ multi shell ( $expression,   :$cwd = $CWD, :%env = %*ENV --> Proc::Status )
 
-C<shell> and C<run> execute an external program, and return control to
+C<run> and C<shell> execute an external program, and return control to
 the caller once the program has exited.
 
 C<shell> goes through the system shell (C<cmd> on windows, C</bin/sh>
@@ -552,6 +552,16 @@ On failure to execute, the routines C<fail()>.
 If you want to execute an external program asynchronously (as in, not waiting
 for it to be finished), you will need C<Proc::Async>, as specced in
 L<S17-concurrency>.
+
+=item runout
+
+C<runout> is a shortcut for C<run> which returns the output (stdout)
+of the external program.
+
+=item shellout
+
+C<shellout> is a shortcut for C<shell> which returns the output (stdout)
+of the external program.
 
 =item runinstead
 
@@ -849,8 +859,8 @@ Because regex escaping metacharacters can easily be solved by quotes
 automatically interpolated (L<S05/Variable (non-)interpolation>), C<quotemeta>
 is no longer needed.
 
-Shell escaping should be handled by passing arguments to L<run>, or with code
-that speaks the language of a specific shell.
+Shell escaping should be overcomed by passing arguments to L<run>, or it could be
+handled with code that speaks the language of a specific shell.
 
 =item pos
 


### PR DESCRIPTION
This text was moved from https://github.com/rakudo/rakudo/pull/554 (some information in this text could refer to implementation details).

----

**TL;DR**: ``qqx//`` should be removed because it is just a booby trap.

I have been mentioning this problem for quite a while (at least since June), but at that time it seemed that deprecating ``qqx//`` is the only way out (which looked too revolutionary).
Now the Christmas is coming and it turns out that removing ``qqx//`` is the right solution, also it is practically the only way out. Better late than never.

**Note:** this text is pretty long. I've tried to keep it short, but if some part is missing then the question will appear in the comments and someone will have to explain it anyway. In other words, here I attempt to answer **all** of the questions, even the simplest ones. This way, we can have a meaningful discussion afterwards (comments are welcome!).

## What's wrong with qqx?

First of all, let's get the security problem straight (even for those who know it). Example:
```perl6
my Str $output = qqx{$*EXECUTABLE $args $filename 2>&1};
```
Given that ext4 filenames can contain any characters except for ``/`` and null byte, what is going to happen:
* if there are spaces *(due to word splitting parts of the filename will end up being in multiple parameters)*
* if there is a ``*`` character *(it will blow up into a list of all files in the directory)*
* if there are some other characters that also happen to be special in shells, e.g. ``#``, `` ` ``, ``&``, ``|`` ``$`` and so on it's not even funny *(… I'm not sure if any explanation is required to demonstrate that you can pass any shell code by using this)*

This is also known as [Shell Injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection). And why not quote the wikipedia if it summarizes the whole problem so clearly:

> However, this still puts the burden on the programmer to know/learn about these functions and remember to make use of them every time they use shell commands. In addition to using these functions, validating or sanitizing the user input is also recommended.

In other words, shell injection is one of the common security vulnerabilities, and people using shell when they don't need it is one of the most common pitfalls. Why not take care of that in Perl6?

More from Wikipedia:
> A safer alternative is to use APIs that execute external programs directly, rather than through a shell, thus preventing the possibility of shell injection. However, these APIs tend to not support various convenience features of shells, and/or to be more cumbersome/verbose compared to concise shell syntax.

Luckily, ``run()`` in Perl6 is pretty convenient. For example, here is how you can pipe two commands ([from docs](http://doc.perl6.org/type/Proc)):
```perl6
my $p1 = run 'echo', 'Hello, world', :out;
my $p2 = run 'cat', '-n', :in($p1.out), :out;
say $p2.out.get;
```
It should actually say ``$p2.out.slurp-rest``, since ``get`` only retrieves the last line (which also sounds like a potential pitfall).

If Perl6 was supposed to help with solutions to common problems (and getting the output of some program is a **very common problem**), then at least one *correct* solution is definitely missing.

## Huffman coding
**We all know** that you should use shell **very** carefully (this sentence is a lie), so what's the big deal?

The problem is that if you want to get it right, you have to type all of this run-out-out-slurp mess. Let's take a look at these simple examples:
```perl6
$output = run('echo', $test, :out).out.slurp-rest;
$output = run(«echo "$test"», :out).out.slurp-rest;
$output = qqx/echo $test/;
```
Huffmanly speaking, which one is better?

The first line is what you **have to do**… it's a disaster.

However, some people might say that they don't like to separate their arguments with commas. Well, although writing command arguments as “run” parameters is probably the most meaningful way to do it, I still see where this stuff is coming from. Okay, there goes the second line, which is basically how you would write it in your shell. **But there's a trick! Beware!** You have to quote **all** your variables, just like you do it in shell. It turns out that it is how « » quoting works, but I saw some disagreement on that part of it. Anyway, whether variables should blow up into separate elements if not quoted or nay, that's a different question. As of 2015-10-10 it works that way and in terms of this pull request it horribly sucks.

So there you have it, one hilariously long line to get the job done, another hilariously long line which is prone to quoting errors, and a third one that is much shorter, yet it is the most dangerous (worst out of all) way to do it.

Here is a quick example to summarize how the same code will look like after this pull request:
```perl6
$output = runout('echo', $test);
$output = runout(«echo "$test"»);
$output = shellout('echo $test');
```
``runout`` is just a shortcut for the previous mess (you can still do it other way, if you wish), ``qqx`` quoting construct is replaced with ``shellout`` sub.

Basically, even right now you can do this instead of using ``qqx``:
```perl6
$output = shell("echo $test", :out).out.slurp-rest;
```
In other words, ``runout`` and ``shellout`` just keep this similarity and constistency.

## Semantics
[S02 mentions](http://design.perl6.org/S02.html#Adverbs_on_quotes) a bunch of adverbs, yet :x is the only one that stands out.

Just think about it! It smashes a string right into the shell, gets the output and returns that to you. Why on earth is that a quoting adverb? Sounds like a regular function call – takes one string and returns another one, as simple as that.

There is a bunch of good candidates for quoting adverbs. Like ``uc`` to make the string uppercase. Or ``flip`` to reverse the string. Just any **Str** method would do, and it would make much more sense.

Let's have quoting adverbs for all of them! Yet we don't. But a thing that spawns a shell, throws your stuff into it, catches the output and gets it back – this one is there… Semantically, does not make enough sense to me.

----
**That's the end of part 1. However, there is a high chance that you might have other questions/thoughts, so here goes the next part.**

## What's wrong with qx?
At first it looks like a tiny innocent feature. Since you can't pass variables into it, then it's fine, right? Still there is some confusion around it.

[The docs say](http://doc.perl6.org/language/quoting#Shell_quoting%3A_qx):

> Nevertheless, if you have declared an environment variable before calling perl6, this will be available within qx, for instance

It says that ENV variables are available within **qx**. That's interesting, right?

And there is an example:
```perl6
say qx{echo "hello $WORLD"}
```
For quite some time I thought (because of the docs) that there is some extra processing involved, yet it took me to dig into rakudo-nqp-moar sources all the way through to see that there is nothing happening on the perl6 side at all. In this case, ``$WORLD`` is an environment variable, __of course__ it will be available in shell (at least that what the programmer would expect). But in **shell**, ``qx`` is not associated with that stuff. Looking at the code, indeed there is some passing of env variables, but it is irrelevant to what the programmer is doing and expecting.

I'm not quite sure whether it is me who understood the docs in the wrong way (yet if I did so I am surely not the only one) or it is the author of this part of the documentation. But what could be noted from this is that sometimes you might feel like Perl6 could be doing something for you, otherwise why is there a special syntax (not just a sub) for that? *Maybe* some kind of weird trickery to save you from such troubles, hopefully!

And this feeling is not really wrong too, **since that's what some people are actually suggesting to fix qqx// problems!**

## Portability
This one is pretty much obvious, but it is just another reason to avoid shell by all means (which is also why we should care about Huffman coding).

[S29](http://design.perl6.org/S29.html#OS) says this about ``shell``:
> shell goes through the system shell (cmd on windows, /bin/sh on Unixish systems), thus interpreting all the usual shell meta characters.

Although ``qx`` is not described in detail, it is probably safe to assume that it will use the system shell (whatever that is). In other words, it is not even close to being portable.

And it is perfectly OK if it has different rules on GNU/Linux than on Microsoft Windows, but what you might not expect is that the shell could work differently even across different GNU/Linux distributions. On some systems ``/bin/sh`` is ``dash``, on others it is ``bash`` (which, by the way, when invoked as ``sh`` will run in POSIX mode), on other systems it could be something else. Yet there are **no guarantees** that all these will perform exactly the same in all corner cases.

Portability should be OK most of the time. However, having a code that *just assumes* what features are available in the shell is bound to fail on some system.

Run, on the other hand, has no such problems (maybe it has other ones?). So that's just another reason to prefer ``run()`` over ``qqx`` (although I think that by the time you read this it should already be crystal clear that ``qqx`` should be avoided by all means. If not, let's continue!)

## Real world examples
I've grepped the whole perl6 module directory for 'qqx' with ``--before 5``:
https://gist.github.com/AlexDaniel/176da249d1314b8cf3a9

It should be mentioned that ``qqx//`` is usually used in user code, there are not many cases when it has to be used by modules. Still, that is something that we can analyze today.

Considering this, what I see here is a heavy **misuse**. At the same time, I can't see any example in the grepped parts when ``run()`` could not be used instead, and I also see wrong ways to mitigate problems associated with shells, for example:
```perl6
$path = qqx{which '$binary' 2>/dev/null}.chomp;
```
Notice these quotes around ``'$binary'``. Look, that's from ``.pm`` file, not even ``.t``! What a disaster…

## Other solutions
Over the time I've gathered other solutions to this problem. Before discussing my commit let's go through other possibilities.

### Shell grammar right in perl6
That would be nice! But unless this solution is explained in detail, it is hard to know whether it solves the problem or not.

You see, perl**5** magically decides whether the shell is used in ``system()`` call or not, such implicit decision is not nice. By making a perl6 feature that will magically pass everything to “run” (including redirection) is OK unless when it's not OK. That is, when using syntactic features that are available in shells only.

It all sounds like we are creating a perl6-based shell. Cool, but I'm sure that this experiment could be done in the module space first. Until then, let's fix ``qqx//``.

### q:r//
Another relatively good solution is to reduce all of the typing burden of ``run()`` by implementing another adverb that will act similarly to ``:x`` but will use ``run()`` underneath. Quoting adverb for this, quoting adverb for that…

While it is a good suggestion, the end result will be that **one character difference** will define whether your code is safe or not.

Also, I'm already imagining the docs and folks on the IRC saying “no-no, don't use qqx//, use qqr// instead!”. Too easy to accidentally use the wrong thing.

On the other hand, ``shell()`` and ``run()`` have much more descriptive names. “shell” should also remind you about “shell injection”, that's descriptive enough.

### qx()
Someone suggested ``qx()`` (a function, not a quoting construct) which will use ``run()`` underneath. Again, one symbol (ok, two) that will make a significant difference. Not good enough.

### Dancing around with qqx
And then there are other suggestions, like, we could attempt to autoquote stuff in ``qqx`` and other similar suggestions. These, however, will change the behavior of ``qqx``, so there has to be some kind of a deprecation cycle. In other words, the same code that was using ``qqx`` could now start doing completely different thing, without any warning.

Although I think that all such suggestions are potentially even worse that what we have now, still for such solutions the deprecation of ``qqx`` is a good idea, since this way we will get a chance to reintroduce it later.

## Possible questions and misunderstandings

### “We can just mention it in the docs!”
**The docs will not fix the language.**

Also, currently the docs just follow the same dumb insecure path as the language itself does: [qx](http://doc.perl6.org/language/quoting#Shell_quoting%3A_qx) and [qqx](http://doc.perl6.org/language/quoting#Shell_quoting_with_interpolation%3A_qqx). Not even a word about possible problems, and surely the examples are all wrong as well:
```perl6
qqx{grep $option $word $file};
```
As you can see, this is an exact use-case for ``run()``. We should not teach people with inappropriate examples. “Here, we do this thing! Which you should actually do with another function, but we do it this way just as an example, but please don't do this.” – that's not OK. But to give a better example… well, someone has to come up with a better example. And yet nobody can do that (here is an interesting quest for the reader!). Usually, all piping examples would be OK, but not in Perl6 where it is just as easy to do it with run.

### “If you need it to be secure, of course you are not going to use shell!”
It is good to have you around, mister programmer-who-knows-everything-and-didn't-ever-write-insecure-code. But not everyone is experienced enough. If we want to make perl6 to be appealing as first language, then let's also remove some of the pitfalls (yet pitfalls in computer languages are usually created unconsciously, while :x in perl6 was implemented on purpose…).

### “What about the specs? What's there?”
The only mention that I could find is in [S02](http://design.perl6.org/S02.html#Q_forms). I've looked into both Apocalypse and Exegesis, but couldn't really find anything. The only thing is this:

> qqx/$cmd @args[]/                   # equivalent to P5's qx//
>
> (Note that qx// doesn't interpolate.)

I couldn't find anything else. It seems like “equivalent to P5's qx//” is the only justification for having it, but it does not take into account that we have much better ways to do this now.

### “Still I think that removing ``qqx//`` is way too revolutionary, is there any other way out?”
First we have to understand why ``qqx//`` was added in the first place. It looks like it is all about hysterical raisins, since perl5 has backticks and backticks in perl5 are pretty popular.

What you should note is that in perl5 there is no other way besides backticks, unlike in perl6 (ok-ok, there is another way which is ``qx``… Also you can use a bunch of other far less obvious alternatives). Look, even ``system()`` will sometimes magically pass everything to shell when you don't really tell it to do so. ``run()`` in perl6 is a huge step forward, and we should use it to make the final step.

### “Why do you care so much?”
I'm tired of fixing and explaining bash quoting. But in bash, unquoted variable does not execute arbitrary code. It might break parameters, it might expand to file names due to globbing, it migh also allow arbitrary code if the program itself allows '-e' flags and such. But all by itself it doesn't cause any code to fire up, yet still it is considered to be a huge error in your code (potentially a security issue).

In perl6 it is much worse, the variable is much like eval-ed in shell. And if we frown upon “eval” so much, then qqx// should be frowned upon just as much and maybe even more. But why bother with that when we can just fix the language?

Also, I was planning to show some real world examples of vulnerabilities (both reported by others and by me), just as a demonstration how wrong Huffman coding could play with programmers in this case, but then I decided that “Forgive and Forget” principle is a much worthy idea than trying to give yet another reason supporting this pull request (also because there are enough reasons already). Also, I don't want to bring any attention to the developers, since they are not guilty, they are just guided by the pitfalls of the languages they are using. For example, some languages require you to fork&exec in order to do it correctly, which definitely is not the easiest way to get your job done (especially when calling the shell is just one function call).

## What other people think about this change
**Please note that these quotations are heavily nit-picked and might not represent the actual position of some person.** Links are provided, so feel free to dig into discussions to see the context.

### Somewhat positive replies (or at least confirmations that the problem is there)
[log](http://irclog.perlgeek.de/perl6/2015-06-27#i_10813924)
> geekosaur: um? you could do it without ShellQuote
> geekosaur: unless your notion of how to do it is incorrect from the start, which tbh is suggested by that response
> geekosaur: (the correct answer is *don't use the shell*)

This answer was directed to me, since I asked what would be the Perl6 equivalent to ShellQuote. Unfortunately, I was biased towards the wrong solution because “system” in perl5 just couldn't get the output (other options are pretty much hidden or just not convenient enough. This is true in lots of other languages). **I was so wrong when I asked this question.** geekosaur++ for spotting the actual problem right away.

----

[log](http://irclog.perlgeek.de/perl6/2015-10-03#i_11312530)
> jnthn: Well, it's good if the langauge guides people towards the Right Thing
> jnthn: I do agree it's unfortunate there's not a succinct way to do with run what qx/qqx currently does with shell.
> jnthn: Well, it's worth thinking about. I think we can do something better than what we have now.

Yea!

----
[log](http://irclog.perlgeek.de/perl6/2015-06-27#i_10813989)
> moritz: I realize the defaults are maybe still the wrong way around, but now Perl 6 has a much nicer API for capturing err/out and no need for quoting


----

### Somewhat negative replies (or at least opinions that the change is not required)
Some people dislike it (ironically sometimes the same people):

[log](http://irclog.perlgeek.de/perl6/2015-07-11#i_10881730)
> ab5tract_: it seems to me that most people would expect such a feature to "shell out"
> ab5tract_: and most people know that shelling out is as insecure as the shell and the commands passed to it

It is hard to confirm that “most people“ people actually do. I'd say that most people don't.

This, however, is a good example demonstrating that the name “shellout” is chosen correctly (more about this later).

----
[log](http://irclog.perlgeek.de/perl6/2015-06-27#i_10814071)
> geekosaur: unclear actually. the problem is if you remove it, someone will re-add it (probably in an even worse way) for convenience

geekosaur is right once again.

But you guys know what? Just don't add it back! Not even with any of this tricky stuff that you want so much!

----
[log](http://irclog.perlgeek.de/perl6/2015-07-11#i_10881486)
> masak: I use `run` when I want the side effect and `qqx` when I want the output.
> masak: I'm sorry, I still don't see the problem. "all sorts of the problems" doesn't quite do it for me as an explanation.
> masak: I've successfully used `qqx` a bunch of times.
> masak: I think I could track down all my uses of qqx ever, and prove formally that they don't have shell quoting problems.
> masak: even if they did, those problems did not manifest for me when I ran the stuff.

Well, although this reply is against this change, we can still learn a lot from it. For example, you can see how the language creates a semantical understanding in the user, which in that case is all wrong. It's not about whether you want the output or not (or the side effect), the question is whether you need the shell.

----
[log](http://irclog.perlgeek.de/perl6/2015-10-03#i_11312513)
> ShimmerFairy: AIUI, the argument is essentially based on making sure the secure version is more Huffman-friendly than the insecure version.
> ShimmerFairy: (which I personally don't think is a very convincing argument to get rid of :x)
> ShimmerFairy: It's only misuse from a security standpoint. I still think the security issue is more appropriately solved with documentation than getting rid of language features in core you don't like.

Documentation will not fix the language. Also, security problem is not a good enough price for imaginary convenience.

Security issues should be solved with documentation? Like if that ever worked…

Think about it, ``shellout 'string goes here'`` is not a disaster to type, you can still shoot your head off whenever you want (__even__ if you think that it will not shoot this time). Yet it is more descriptive, Huffman coding is correct, and also it does not create imaginary feeling that the language will somehow save your ass by applying some weird quoting rules.

### Why “shellout” and “runout” names were chosen?

Some people dislike it:
> Woodi: shellout/runout names are bad, IMO
> jnthn: I don't see the names runout/shellout really flying.

But at the same time it is already in use.

[Quote from perlmonks](http://www.perlmonks.org/?node_id=1095597):
> Wrapping shell scripts in Perl tends (NB: 'tends!') to be a less than optimal solution for many/most problem cases. Perl can probably do the job with its native capabilities, without the overhead of **shelling-out**.

Here is [an article called “Shelling Out Sucks”](http://julialang.org/blog/2012/03/shelling-out-sucks/). **Which is also a good read for folks who think that ``qqx//`` is still good enough for “simple cases”.**

[“Should your scripts shell out, they're exploitable.”](http://www.perlmonks.org/?node_id=1101954) – although taken out of context, it is still true. By the way, it is one more example how avoiding the shell (and thus complexity) can pay out in a long run.

Therefore, I think that the name “shellout” is more than appropriate. “runout” is a little bit weird though, but still good enough.

If someone asks “what is the difference between ``shell`` and ``shellout`` if both are shelling out?” then the answer is “``shellout`` returns the **out**put”. It fits, I think.

If you want to recommend another name – great! Some good requirements:
* The word “shell” must be there. If the thing is flammable, they put a special icon on it (and textual warnings as well!). That's also what we should do. See also one of the previous sections about ``qqr//``.
* ``run()``-like alternative should also be named similarly to keep it strangely consistent.
* Just like “runout” is shorter than “shellout”, your suggested names should keep it the same way (Huffman coding).

As a side note, ``qqx//`` (as implemented right now) should have been called ``qq☠//`` (which is also a good solution for those who want to make it stay, yet I think that **they have to come up with reasons to keep it**, even if they want it to be renamed like this).

### But I have no time to split my arguments with commas!
Ok then! Instead of this:
```perl6
qqx{grep $option $word $file}; # broken because of the shell injection AND because the variables are not quoted
```
You should do this:
```perl6
runout «grep "$option" "$word" "$file"»;
```
Which is exactly how you write it in your terminal! That is, just copy paste it.

Surely if you forget the quotes, then it will all blow up again. Not as hard as if you forget to quote it in shell. Still, this solution is not good enough to be recommended in public, since **the history has demonstrated that most people don't quote their variables in bash**. Hoping that they will start doing it in Perl6 is wishful thinking.

But if you are so lazy to put the commas, then there you go. There is more than one way to do it, and some of these ways come bundled with a rope. This solution has enough rope for you, I hope.

## Conclusion
I think that I gave enough reasons to remove ``qqx//`` (and its friends), and although I keep asking for reasons to keep it I still could not find any. People keep trying to come up with different solutions to the problem, and that's fine, but it all ends up with deprecating ``qqx//`` anyway. Other solutions to this problem could be tested in module space, for now “runout” and “shellout” shortcuts are great since it solves the problem in a meaningful and correct way.

When this pull request is accepted (or if the issue is fixed with a similar commit, e.g. with different sub names), I will write some tests, fix the docs, send pull requests to module maintaners and change rosettacode examples if any, all according to the removal of :x. That is, I'm hoping that nothing is required from anybody else.
