### PR TITLE
[S04] Add missing parenthesis in zip() example

### DIFF
--- a/S04-control.pod
+++ b/S04-control.pod
@@ -523,8 +523,8 @@ than one element at a time:
 To process two arrays in parallel use the C<zip> function to generate a list
 that can be bound to the corresponding number of parameters:
 
-    for zip(@a;@b) -> $a, $b { print "[$a, $b]\n" }
-    for @a Z @b -> $a, $b { print "[$a, $b]\n" }        # same thing
+    for zip(@a, @b) -> ($a, $b) { print "[$a, $b]\n" }
+    for @a Z @b -> ($a, $b) { print "[$a, $b]\n" }        # same thing
 
 The list is evaluated lazily by default, so instead of using a C<while> to
 read a file a line at a time as you would in Perl 5:


### PR DESCRIPTION
This change makes the design doc match the roast test.