### PR TITLE
prohibit mixing visible and non-visible column separator types in a t…

### DIFF
--- a/S26-documentation.pod
+++ b/S26-documentation.pod
@@ -1416,12 +1416,14 @@ Simple tables can be specified in Pod using a C<=table> block.
 The table may be given an associated description or title using the
 C<:caption> option.
 
-Columns are separated by two or more consecutive whitespace characters,
+Columns are separated by two or more consecutive whitespace characters
+(double-space),
 or by a vertical line (C<|>) or a border intersection (C<+>), either of
 which must be separated from any content by at least one whitespace
-character.  Note that only one column separator type is allowed on a single line,
-but different lines are allowed to use different column separator types
-(that style is not recommended).
+character.  Note that only one column separator type is allowed in a single line,
+but different lines are allowed to use different visible column separator types
+(that style is not recommended).  Using a mixture of visible and non-visible
+column separator types in a table is an error.
 
 Rows can be specified in one of two ways: either one row per line, with
 no separators; or multiple lines per row with explicit horizontal


### PR DESCRIPTION
…able

Reasonable table parsing requires the restriction.  None of the present spec test tables use a mixture of visible and non-visible column separator types. 