### PR TITLE
Update META info for the license section

### DIFF
--- a/S22-package-format.pod
+++ b/S22-package-format.pod
@@ -425,11 +425,25 @@ a distribution is installed, it can be loaded just like any other distribution.
 
 =head3 license
 
-Optional.  The URL with the text of the license under which this distribution
-is available for installation.  Or some other way to indicate the license,
-e.g. inspired by the Perl 5 module L<Software::License>.
+Recommended. The L<SPDX|https://spdx.org/licenses> license identifier that the
+package is distributed under.
 
-  "license" : "http://www.gnu.org/licenses/gpl-1.0.html"
+"By providing a short identifier, users can efficiently refer to a license without
+having to redundantly reproduce the full license".
+
+SPDX licenses are meant to be interoperable and are the most widely used set
+of identifiers for licenses.
+
+  "license" : "Artistic-2.0"
+
+If the license isn't on the SPDX standardized list, it is highly recommended to
+include a URL with the text of the license under the support key in addition to the name
+of the license.
+
+  "license" : "Artistic-2.0",
+  "support": {
+    "license": "http://www.perlfoundation.org/artistic_license_2_0"
+  },
 
 =head3 tags
 


### PR DESCRIPTION
Use the SPDX license identifier under license, which is the most widely
used license tags meant for interoperability.

If the license does not have an identifier, then it is recommended to
add a URL to the license under the support key.