### PR TITLE
tell: use the term "bytes" instead of "octets"

### DIFF
--- a/S32-setting-library/IO.pod
+++ b/S32-setting-library/IO.pod
@@ -1239,7 +1239,7 @@ X<.tell>
 
     method tell(--> Int)
 
-Returns the position of the file pointer in number of "octets".
+Returns the position of the file pointer in "bytes".
 
 =head3  .write
 X<.write>


### PR DESCRIPTION
Make "tell" and "seek" use the same unit. 

https://github.com/perl6/specs/issues/85